### PR TITLE
Standardize Databricks notebook logging and translate French content

### DIFF
--- a/databricks/notebooks/ml_export_to_knime.py
+++ b/databricks/notebooks/ml_export_to_knime.py
@@ -40,6 +40,8 @@
 # COMMAND ----------
 
 # DBTITLE 1,Cell 4
+import logging
+
 from pyspark.sql.functions import (
     col, lit, year, month, hour, minute, dayofweek,
     when, coalesce, to_timestamp, date_format,
@@ -50,6 +52,10 @@ from pyspark.sql.functions import (
 from pyspark.sql.window import Window
 from pyspark.sql import DataFrame
 import datetime
+
+logger = logging.getLogger(__name__)
+if not logger.handlers:
+    logger.setLevel(logging.INFO)
 
 storage_account_name = "adlsbellevuegrp3"
 storage_account_key  = dbutils.secrets.get(scope="keyvault-scope", key="adls-access-key")
@@ -62,8 +68,8 @@ spark.conf.set(
 silver_base = f"abfss://silver@{storage_account_name}.dfs.core.windows.net"
 ml_base     = f"abfss://mldata@{storage_account_name}.dfs.core.windows.net"
 
-print(f"✅ Silver : {silver_base}")
-print(f"✅ ML     : {ml_base}")
+logger.info("Silver : %s", silver_base)
+logger.info("ML     : %s", ml_base)
 
 # COMMAND ----------
 
@@ -94,7 +100,7 @@ df_solar = (
     .orderBy("timestamp")
 )
 
-print(f"✅ solar_aggregated   : {df_solar.count():,} rows")
+logger.info("solar_aggregated   : %s rows", f"{df_solar.count():,}")
 df_solar.show(3, truncate=False)
 
 # COMMAND ----------
@@ -120,7 +126,7 @@ df_conso = (
     .orderBy("timestamp")
 )
 
-print(f"✅ consumption        : {df_conso.count():,} rows")
+logger.info("consumption        : %s rows", f"{df_conso.count():,}")
 df_conso.show(3, truncate=False)
 
 # COMMAND ----------
@@ -191,7 +197,7 @@ df_weather_pivot = (
     .orderBy("timestamp_3h")
 )
 
-print(f"✅ weather (3h pivot) : {df_weather_pivot.count():,} rows")
+logger.info("weather (3h pivot) : %s rows", f"{df_weather_pivot.count():,}")
 df_weather_pivot.show(3, truncate=False)
 
 # COMMAND ----------
@@ -245,7 +251,7 @@ df_weather_15min = (
     .filter(col("irradiance_wm2").isNotNull())  # Remove slots before first weather measurement
 )
 
-print(f"✅ weather (15min ff) : {df_weather_15min.count():,} rows")
+logger.info("weather (15min ff) : %s rows", f"{df_weather_15min.count():,}")
 df_weather_15min.show(3, truncate=False)
 
 # COMMAND ----------
@@ -274,7 +280,8 @@ df_bookings_raw = (
     .select("Date", "Heure_Debut", "Heure_Fin", "Nom")
 )
 
-# Convert French dates → start and end timestamps
+# Convert French dates → start and end timestamps.
+# Source values from bookings CSV — do not translate (regex matches actual French data).
 french_months_map = [
     ("janv\\.", "Jan"), ("févr\\.", "Feb"), ("mars", "Mar"),
     ("avr\\.",  "Apr"), ("mai",     "May"), ("juin", "Jun"),
@@ -305,7 +312,7 @@ df_bookings = (
 
 # Total distinct known rooms (denominator for occupation rate)
 total_rooms = df_bookings.select("room_code").distinct().count()
-print(f"   Total distinct rooms: {total_rooms}")
+logger.info("Total distinct rooms: %d", total_rooms)
 
 # Generate all 15-min slots covered by each booking
 # Each slot = timestamp rounded down to the nearest 15-min where the room is occupied
@@ -343,7 +350,7 @@ df_occupation = (
     )
 )
 
-print(f"✅ room occupation    : {df_occupation.count():,} slots")
+logger.info("room occupation    : %s slots", f"{df_occupation.count():,}")
 df_occupation.show(3, truncate=False)
 
 # COMMAND ----------
@@ -427,9 +434,12 @@ df_us29 = (
 )
 
 n_us29 = df_us29.count()
-print(f"✅ US#29 dataset : {n_us29:,} rows")
-print(f"   Period       : {df_us29.agg({'timestamp': 'min'}).collect()[0][0]} "
-      f"→ {df_us29.agg({'timestamp': 'max'}).collect()[0][0]}")
+logger.info("US#29 dataset : %s rows", f"{n_us29:,}")
+logger.info(
+    "   Period       : %s -> %s",
+    df_us29.agg({'timestamp': 'min'}).collect()[0][0],
+    df_us29.agg({'timestamp': 'max'}).collect()[0][0],
+)
 df_us29.show(5, truncate=False)
 
 # COMMAND ----------
@@ -483,9 +493,12 @@ df_us30 = (
 )
 
 n_us30 = df_us30.count()
-print(f"✅ US#30 dataset : {n_us30:,} rows")
-print(f"   Period       : {df_us30.agg({'timestamp': 'min'}).collect()[0][0]} "
-      f"→ {df_us30.agg({'timestamp': 'max'}).collect()[0][0]}")
+logger.info("US#30 dataset : %s rows", f"{n_us30:,}")
+logger.info(
+    "   Period       : %s -> %s",
+    df_us30.agg({'timestamp': 'min'}).collect()[0][0],
+    df_us30.agg({'timestamp': 'max'}).collect()[0][0],
+)
 df_us30.show(5, truncate=False)
 
 # COMMAND ----------
@@ -512,13 +525,13 @@ output_us30 = f"{ml_base}/knime_input/consumption_features"
 # Delete old version before writing (idempotence)
 try:
     dbutils.fs.rm(output_us29, recurse=True)
-    print(f"🗑️  Old version deleted: {output_us29}")
+    logger.info("Old version deleted: %s", output_us29)
 except Exception:
     pass
 
 try:
     dbutils.fs.rm(output_us30, recurse=True)
-    print(f"🗑️  Old version deleted: {output_us30}")
+    logger.info("Old version deleted: %s", output_us30)
 except Exception:
     pass
 
@@ -533,7 +546,7 @@ except Exception:
     .option("encoding", "UTF-8")
     .csv(output_us29)
 )
-print(f"✅ Exported → {output_us29}  ({n_us29:,} rows)")
+logger.info("Exported -> %s  (%s rows)", output_us29, f"{n_us29:,}")
 
 # Export US#30 — Consumption
 (
@@ -546,7 +559,7 @@ print(f"✅ Exported → {output_us29}  ({n_us29:,} rows)")
     .option("encoding", "UTF-8")
     .csv(output_us30)
 )
-print(f"✅ Exported → {output_us30}  ({n_us30:,} rows)")
+logger.info("Exported -> %s  (%s rows)", output_us30, f"{n_us30:,}")
 
 # COMMAND ----------
 
@@ -557,9 +570,9 @@ print(f"✅ Exported → {output_us30}  ({n_us30:,} rows)")
 # COMMAND ----------
 
 # DBTITLE 1,Untitled
-print("=" * 70)
-print("EXPORT SUMMARY — ml_export_to_knime.py")
-print("=" * 70)
+logger.info("=" * 70)
+logger.info("EXPORT SUMMARY — ml_export_to_knime.py")
+logger.info("=" * 70)
 
 for path, label, n in [
     (output_us29, "solar_production_features.csv  [US#29]", n_us29),
@@ -568,24 +581,22 @@ for path, label, n in [
     files = dbutils.fs.ls(path)
     csv_files = [f for f in files if f.name.endswith(".csv")]
     size_kb = csv_files[0].size // 1024 if csv_files else 0
-    print(f"\n  {label}")
-    print(f"    Rows    : {n:,}")
-    print(f"    Size    : ~{size_kb:,} KB")
-    print(f"    Path    : {path}/")
+    logger.info("  %s", label)
+    logger.info("    Rows    : %s", f"{n:,}")
+    logger.info("    Size    : ~%s KB", f"{size_kb:,}")
+    logger.info("    Path    : %s/", path)
 
-print()
-print("US#29 Schema (KNIME features):")
+logger.info("US#29 Schema (KNIME features):")
 df_us29.printSchema()
 
-print("US#30 Schema (KNIME features):")
+logger.info("US#30 Schema (KNIME features):")
 df_us30.printSchema()
 
-print()
-print("=" * 70)
-print("Expected KNIME OUTPUT format (for ml_load_predictions.py — US#31):")
-print("  knime_output/production_predictions.csv")
-print("    → columns: timestamp (yyyy-MM-dd HH:mm:ss), predicted_production_kwh")
-print("  knime_output/consumption_predictions.csv")
-print("    → columns: timestamp (yyyy-MM-dd HH:mm:ss), predicted_consumption_kwh")
-print("=" * 70)
-print("✅ Export complete — KNIME can start.")
+logger.info("=" * 70)
+logger.info("Expected KNIME OUTPUT format (for ml_load_predictions.py — US#31):")
+logger.info("  knime_output/production_predictions.csv")
+logger.info("    -> columns: timestamp (yyyy-MM-dd HH:mm:ss), predicted_production_kwh")
+logger.info("  knime_output/consumption_predictions.csv")
+logger.info("    -> columns: timestamp (yyyy-MM-dd HH:mm:ss), predicted_consumption_kwh")
+logger.info("=" * 70)
+logger.info("Export complete — KNIME can start.")

--- a/databricks/notebooks/ml_load_predictions.py
+++ b/databricks/notebooks/ml_load_predictions.py
@@ -32,6 +32,8 @@
 # COMMAND ----------
 
 # DBTITLE 1,Cell 4
+import logging
+
 from pyspark.sql.functions import (
     col, lit, to_timestamp, date_format,
     year, month, hour, minute,
@@ -39,6 +41,10 @@ from pyspark.sql.functions import (
 )
 from pyspark.sql import DataFrame
 import time, json
+
+logger = logging.getLogger(__name__)
+if not logger.handlers:
+    logger.setLevel(logging.INFO)
 
 # ── ADLS ──────────────────────────────────────────────────────────────────────
 storage_account_name = "adlsbellevuegrp3"
@@ -85,8 +91,10 @@ def _jdbc_retry(fn, max_attempts: int = 5, initial_wait: int = 20):
             if "not currently available" in msg or "connection" in msg.lower():
                 if attempt == max_attempts:
                     raise
-                print(f"⚠️  Azure SQL waking up (attempt {attempt}/{max_attempts}) "
-                      f"— retrying in {wait}s...")
+                logger.warning(
+                    "Azure SQL waking up (attempt %d/%d) — retrying in %ds...",
+                    attempt, max_attempts, wait,
+                )
                 time.sleep(wait)
                 wait += initial_wait
             else:
@@ -129,9 +137,9 @@ def ts_to_timekey(ts_col):
     return (hour(ts_col) * 60 + minute(ts_col)).cast("short")
 
 
-print("✅ Configuration loaded.")
-print(f"   ML input/output : {ml_base}")
-print(f"   Gold (Azure SQL): {sql_server}.database.windows.net / {sql_database}")
+logger.info("Configuration loaded.")
+logger.info("   ML input/output : %s", ml_base)
+logger.info("   Gold (Azure SQL): %s.database.windows.net / %s", sql_server, sql_database)
 
 # COMMAND ----------
 
@@ -162,7 +170,7 @@ missing_prod       = expected_cols_prod - actual_cols_prod
 
 if missing_prod:
     raise ValueError(
-        f"❌ production_predictions.csv — missing columns: {missing_prod}\n"
+        f"production_predictions.csv — missing columns: {missing_prod}\n"
         f"   Columns found: {actual_cols_prod}\n"
         f"   Check the 'Column Rename' configuration in KNIME workflow US#29."
     )
@@ -181,7 +189,7 @@ df_prod_preds = (
     .orderBy("ts")
 )
 
-print(f"✅ production_predictions: {df_prod_preds.count():,} rows")
+logger.info("production_predictions: %s rows", f"{df_prod_preds.count():,}")
 df_prod_preds.show(3, truncate=False)
 
 # COMMAND ----------
@@ -206,7 +214,7 @@ missing_conso       = expected_cols_conso - actual_cols_conso
 
 if missing_conso:
     raise ValueError(
-        f"❌ consumption_predictions.csv — missing columns: {missing_conso}\n"
+        f"consumption_predictions.csv — missing columns: {missing_conso}\n"
         f"   Columns found: {actual_cols_conso}\n"
         f"   Check the 'Column Rename' configuration in KNIME workflow US#30."
     )
@@ -225,7 +233,7 @@ df_conso_preds = (
     .orderBy("ts")
 )
 
-print(f"✅ consumption_predictions: {df_conso_preds.count():,} rows")
+logger.info("consumption_predictions: %s rows", f"{df_conso_preds.count():,}")
 df_conso_preds.show(3, truncate=False)
 
 # COMMAND ----------
@@ -247,7 +255,7 @@ import datetime
 
 # Pipeline execution date (today)
 run_date_key = int(datetime.date.today().strftime("%Y%m%d"))
-print(f"   PredictionRunDateKey: {run_date_key}")
+logger.info("   PredictionRunDateKey: %d", run_date_key)
 
 # Retrieve ModelKey from dim_prediction_model
 df_models = read_gold("dim_prediction_model").select("ModelKey", "ModelCode").cache()
@@ -258,19 +266,19 @@ model_key_us30 = models_map.get(MODEL_CODE_US30)
 
 if model_key_us29 is None:
     raise ValueError(
-        f"❌ ModelCode '{MODEL_CODE_US29}' not found in dim_prediction_model.\n"
+        f"ModelCode '{MODEL_CODE_US29}' not found in dim_prediction_model.\n"
         f"   Available models: {list(models_map.keys())}\n"
         f"   Run silver_gold_dimensions.py to initialize the dimension."
     )
 if model_key_us30 is None:
     raise ValueError(
-        f"❌ ModelCode '{MODEL_CODE_US30}' not found in dim_prediction_model.\n"
+        f"ModelCode '{MODEL_CODE_US30}' not found in dim_prediction_model.\n"
         f"   Available models: {list(models_map.keys())}\n"
         f"   Run silver_gold_dimensions.py to initialize the dimension."
     )
 
-print(f"✅ ModelKey US#29 (production)  : {model_key_us29}  [{MODEL_CODE_US29}]")
-print(f"✅ ModelKey US#30 (consumption) : {model_key_us30}  [{MODEL_CODE_US30}]")
+logger.info("ModelKey US#29 (production)  : %s  [%s]", model_key_us29, MODEL_CODE_US29)
+logger.info("ModelKey US#30 (consumption) : %s  [%s]", model_key_us30, MODEL_CODE_US30)
 df_models.unpersist()
 
 # COMMAND ----------
@@ -294,7 +302,7 @@ exec_sql(f"""
     DELETE FROM fact_energy_prediction
     WHERE PredictionRunDateKey = {run_date_key}
 """)
-print(f"🗑️  Existing predictions for RunDateKey={run_date_key} deleted.")
+logger.info("Existing predictions for RunDateKey=%d deleted.", run_date_key)
 
 # COMMAND ----------
 
@@ -326,7 +334,7 @@ df_fact_prod = (
 
 n_prod = df_fact_prod.count()
 write_gold(df_fact_prod, "fact_energy_prediction")
-print(f"✅ fact_energy_prediction (production)  : {n_prod:,} rows inserted.")
+logger.info("fact_energy_prediction (production)  : %s rows inserted.", f"{n_prod:,}")
 
 # COMMAND ----------
 
@@ -358,7 +366,7 @@ df_fact_conso = (
 
 n_conso = df_fact_conso.count()
 write_gold(df_fact_conso, "fact_energy_prediction")
-print(f"✅ fact_energy_prediction (consumption): {n_conso:,} rows inserted.")
+logger.info("fact_energy_prediction (consumption): %s rows inserted.", f"{n_conso:,}")
 
 # COMMAND ----------
 
@@ -380,7 +388,7 @@ dates_prod  = [row["DateKey"] for row in df_fact_prod.select("DateKey").distinct
 dates_conso = [row["DateKey"] for row in df_fact_conso.select("DateKey").distinct().collect()]
 all_dates   = sorted(set(dates_prod) | set(dates_conso))
 
-print(f"   Dates to backfill: {len(all_dates)} days")
+logger.info("   Dates to backfill: %d days", len(all_dates))
 
 backfill_ok = 0
 for dk in all_dates:
@@ -391,9 +399,9 @@ for dk in all_dates:
         backfill_ok += 1
     except Exception as e:
         # Non-fatal: actuals for the day may not be available yet
-        print(f"   ⚠️  Backfill skipped for {date_str}: {e}")
+        logger.warning("   Backfill skipped for %s: %s", date_str, e)
 
-print(f"✅ Backfill completed: {backfill_ok}/{len(all_dates)} days processed.")
+logger.info("Backfill completed: %d/%d days processed.", backfill_ok, len(all_dates))
 
 # COMMAND ----------
 
@@ -414,10 +422,10 @@ config_path = f"{ml_base}/ml_models_config.json"
 try:
     raw = dbutils.fs.head(config_path, 65536)
     models_cfg = json.loads(raw)
-    print(f"✅ Existing ML config loaded ({len(models_cfg)} models).")
+    logger.info("Existing ML config loaded (%d models).", len(models_cfg))
 except Exception:
     models_cfg = []
-    print("⚠️  ML config not found — creating new config.")
+    logger.warning("ML config not found — creating new config.")
 
 # Metadata for the KNIME models actually used
 KNIME_MODELS_META = {
@@ -460,15 +468,15 @@ existing_codes = {m["ModelCode"]: i for i, m in enumerate(models_cfg)}
 for code, meta in KNIME_MODELS_META.items():
     if code in existing_codes:
         models_cfg[existing_codes[code]].update(meta)
-        print(f"✅ Config updated: '{code}'")
+        logger.info("Config updated: '%s'", code)
     else:
         models_cfg.append(meta)
-        print(f"✅ Config added  : '{code}'")
+        logger.info("Config added  : '%s'", code)
 
 # Write updated config to ADLS
 updated_json = json.dumps(models_cfg, indent=2, ensure_ascii=False)
 dbutils.fs.put(config_path, updated_json, overwrite=True)
-print(f"✅ ml_models_config.json written → {config_path}")
+logger.info("ml_models_config.json written -> %s", config_path)
 
 # COMMAND ----------
 
@@ -479,9 +487,9 @@ print(f"✅ ml_models_config.json written → {config_path}")
 # COMMAND ----------
 
 # DBTITLE 1,Cell 23
-print("=" * 70)
-print("SUMMARY — ml_load_predictions.py (US#28 + US#31)")
-print("=" * 70)
+logger.info("=" * 70)
+logger.info("SUMMARY — ml_load_predictions.py (US#28 + US#31)")
+logger.info("=" * 70)
 
 # Count by model in fact_energy_prediction
 df_check = spark.read.jdbc(
@@ -514,10 +522,9 @@ df_actuals = spark.read.jdbc(
 )
 
 row = df_actuals.collect()[0]
-print(f"   Total rows inserted     : {row['Total']:,}")
-print(f"   Production actuals      : {row['ProdActuals']:,}")
-print(f"   Consumption actuals     : {row['ConsoActuals']:,}")
-print()
-print("✅ Complete ML pipeline — fact_energy_prediction up to date.")
-print("   → vw_prediction_accuracy is now populated for Power BI.")
-print("=" * 70)
+logger.info("   Total rows inserted     : %s", f"{row['Total']:,}")
+logger.info("   Production actuals      : %s", f"{row['ProdActuals']:,}")
+logger.info("   Consumption actuals     : %s", f"{row['ConsoActuals']:,}")
+logger.info("Complete ML pipeline — fact_energy_prediction up to date.")
+logger.info("   -> vw_prediction_accuracy is now populated for Power BI.")
+logger.info("=" * 70)

--- a/databricks/notebooks/sac_export_to_adls.py
+++ b/databricks/notebooks/sac_export_to_adls.py
@@ -16,6 +16,12 @@
 
 # COMMAND ----------
 
+import logging
+
+logger = logging.getLogger(__name__)
+if not logger.handlers:
+    logger.setLevel(logging.INFO)
+
 storage_account_name = "adlsbellevuegrp3"
 storage_account_key  = dbutils.secrets.get(scope="keyvault-scope", key="adls-access-key")
 
@@ -43,8 +49,8 @@ jdbc_props = {
     "driver":   "com.microsoft.sqlserver.jdbc.SQLServerDriver",
 }
 
-print(f"✅ ADLS SAC target : {sac_base}")
-print(f"✅ Azure SQL       : {sql_server}.database.windows.net / {sql_database}")
+logger.info("ADLS SAC target : %s", sac_base)
+logger.info("Azure SQL       : %s.database.windows.net / %s", sql_server, sql_database)
 
 # COMMAND ----------
 
@@ -86,7 +92,7 @@ df_combined = spark.read.jdbc(
 )
  
 n_combined = df_combined.count()
-print(f"✅ Combined (status + performance) : {n_combined:,} rows")
+logger.info("Combined (status + performance) : %s rows", f"{n_combined:,}")
 
 # COMMAND ----------
 
@@ -102,7 +108,7 @@ final_combined = f"{sac_base}/sac_inverter_combined.csv"
 for path in [tmp_combined, final_combined]:
     try:
         dbutils.fs.rm(path, recurse=True)
-        print(f"🗑️  Removed: {path}")
+        logger.info("Removed: %s", path)
     except Exception:
         pass
 
@@ -137,7 +143,7 @@ def promote_csv(tmp_dir, final_path, label):
         raise FileNotFoundError(f"No CSV found in {tmp_dir}")
     dbutils.fs.mv(part_csv[0], final_path)
     dbutils.fs.rm(tmp_dir, recurse=True)
-    print(f"✅ {label} → {final_path}")
+    logger.info("%s -> %s", label, final_path)
 
 promote_csv(tmp_combined, final_combined, f"sac_inverter_combined.csv ({n_combined:,} rows)")
 
@@ -148,15 +154,15 @@ promote_csv(tmp_combined, final_combined, f"sac_inverter_combined.csv ({n_combin
 
 # COMMAND ----------
 
-print("=" * 70)
-print("SAC EXPORT SUMMARY")
-print("=" * 70)
-
 info    = dbutils.fs.ls(final_combined)
 size_kb = info[0].size // 1024
-print(f"\n  sac_inverter_combined.csv  [US#25 — failures + performance]")
-print(f"    Rows   : {n_combined:,}")
-print(f"    Size   : ~{size_kb:,} KB")
-print(f"    Path   : {final_combined}")
-print("\n✅ Export complete — download sac_inverter_combined.csv from ADLS sacexport/ and upload to SAC.")
-print("=" * 70)
+
+logger.info("=" * 70)
+logger.info("SAC EXPORT SUMMARY")
+logger.info("=" * 70)
+logger.info("  sac_inverter_combined.csv  [US#25 — failures + performance]")
+logger.info("    Rows   : %s", f"{n_combined:,}")
+logger.info("    Size   : ~%s KB", f"{size_kb:,}")
+logger.info("    Path   : %s", final_combined)
+logger.info("Export complete — download sac_inverter_combined.csv from ADLS sacexport/ and upload to SAC.")
+logger.info("=" * 70)

--- a/databricks/notebooks/silver_gold_dimensions.py
+++ b/databricks/notebooks/silver_gold_dimensions.py
@@ -36,11 +36,17 @@
 # COMMAND ----------
 
 # DBTITLE 1,Cell 4
+import logging
+
 from pyspark.sql.functions import (
     col, lit, when, regexp_extract, upper, trim, max as spark_max
 )
 import re
 import time
+
+logger = logging.getLogger(__name__)
+if not logger.handlers:
+    logger.setLevel(logging.INFO)
 
 # ── Azure Data Lake Storage ────────────────────────────────────────────
 storage_account_name = "adlsbellevuegrp3"
@@ -70,7 +76,7 @@ def wake_up_sql(max_wait: int = 120):
     Wakes up Azure SQL Serverless by attempting a simple connection in a loop.
     The database takes ~20-60s to start after a period of inactivity.
     """
-    print("⏳ Checking Azure SQL availability...")
+    logger.info("Checking Azure SQL availability...")
     deadline = time.time() + max_wait
     attempt = 0
     while time.time() < deadline:
@@ -80,12 +86,12 @@ def wake_up_sql(max_wait: int = 120):
                 jdbc_url, sql_user, sql_password
             )
             conn.close()
-            print(f"✅ Azure SQL available (attempt {attempt})")
+            logger.info("Azure SQL available (attempt %d)", attempt)
             return
         except Exception as e:
             if "not currently available" in str(e):
                 elapsed = int(time.time() - (deadline - max_wait))
-                print(f"   Database waking up... ({elapsed}s elapsed, attempt {attempt})")
+                logger.info("Database waking up... (%ds elapsed, attempt %d)", elapsed, attempt)
                 time.sleep(15)
             else:
                 raise  # Other error (auth, network) → fail immediately
@@ -111,8 +117,10 @@ def _jdbc_retry(fn, max_attempts: int = 5, initial_wait: int = 20):
             if "not currently available" in msg or "connection" in msg.lower():
                 if attempt == max_attempts:
                     raise
-                print(f"⚠️  Azure SQL waking up (attempt {attempt}/{max_attempts}) "
-                      f"— retrying in {wait}s...")
+                logger.warning(
+                    "Azure SQL waking up (attempt %d/%d) — retrying in %ds...",
+                    attempt, max_attempts, wait,
+                )
                 time.sleep(wait)
                 wait += initial_wait
             else:
@@ -133,9 +141,9 @@ def exec_sql(statement: str):
             conn.close()
     _jdbc_retry(_run)
 
-print("✅ Configuration loaded.")
-print(f"   Silver : {silver_base}")
-print(f"   Gold   : {sql_server}.database.windows.net / {sql_database}")
+logger.info("Configuration loaded.")
+logger.info("   Silver : %s", silver_base)
+logger.info("   Gold   : %s.database.windows.net / %s", sql_server, sql_database)
 
 # COMMAND ----------
 
@@ -166,7 +174,7 @@ df_inv_new = df_inv_silver.join(df_inv_gold, on="InverterID", how="left_anti")
 new_ids = [row["InverterID"] for row in df_inv_new.collect()]
 
 if not new_ids:
-    print("✅ dim_inverter: no new inverters detected.")
+    logger.info("dim_inverter: no new inverters detected.")
 else:
     for inv_id in new_ids:
         exec_sql(f"""
@@ -176,7 +184,7 @@ else:
             VALUES
                 ({inv_id}, 'INV-{inv_id:02d}', 6.00, 2, NULL, NULL, 1)
         """)
-    print(f"✅ dim_inverter: {len(new_ids)} new inverter(s) inserted → IDs {new_ids}")
+    logger.info("dim_inverter: %d new inverter(s) inserted -> IDs %s", len(new_ids), new_ids)
 
 # COMMAND ----------
 
@@ -213,7 +221,7 @@ STATUS_LABELS = {
 new_codes = [row["StatusCode"] for row in df_status_new.collect()]
 
 if not new_codes:
-    print("✅ dim_inverter_status: no new codes detected.")
+    logger.info("dim_inverter_status: no new codes detected.")
 else:
     for code in new_codes:
         label, category, is_failure, requires_maint = STATUS_LABELS.get(
@@ -226,7 +234,7 @@ else:
             VALUES
                 ({code}, '{label}', '{category}', {is_failure}, {requires_maint})
         """)
-    print(f"✅ dim_inverter_status: {len(new_codes)} new code(s) inserted → {new_codes}")
+    logger.info("dim_inverter_status: %d new code(s) inserted -> %s", len(new_codes), new_codes)
 
 # Sentinel 99 (always present for missing FKs)
 exec_sql("""
@@ -249,7 +257,7 @@ exec_sql("""
 # COMMAND ----------
 
 # DBTITLE 1,Cell 10
-# ⚠️  Known site coordinates — extend if new sites appear
+# Known site coordinates — extend if new sites appear
 SITE_META = {
     "Sion":    {"desc": "MeteoSwiss Station — Sion (VS). Southwest reference.",
                 "is_synthetic": 0, "lat": 46.2167, "lon": 7.3500, "alt": 482},
@@ -276,7 +284,7 @@ if "Sierre" not in [row["SiteName"] for row in df_sites_gold.collect()]:
     new_sites.append("Sierre")
 
 if not new_sites:
-    print("✅ dim_weather_site: no new sites detected.")
+    logger.info("dim_weather_site: no new sites detected.")
 else:
     for site in new_sites:
         meta = SITE_META.get(site, {
@@ -293,7 +301,7 @@ else:
             VALUES
                 ('{site}', '{meta["desc"]}', {meta["is_synthetic"]}, {lat}, {lon}, {alt}, 'CH')
         """)
-    print(f"✅ dim_weather_site: {len(new_sites)} new site(s) inserted → {new_sites}")
+    logger.info("dim_weather_site: %d new site(s) inserted -> %s", len(new_sites), new_sites)
 
 # COMMAND ----------
 
@@ -330,7 +338,7 @@ df_meas_new  = df_meas_silver.join(df_meas_gold, on="MeasurementCode", how="left
 new_measurements = df_meas_new.collect()
 
 if not new_measurements:
-    print("✅ dim_measurement_type: no new measurement types detected.")
+    logger.info("dim_measurement_type: no new measurement types detected.")
 else:
     for row in new_measurements:
         code = row["MeasurementCode"].replace("'", "''")
@@ -348,7 +356,7 @@ else:
                 ('{code}', '{name}', '{category}', '{unit_ref}',
                  'Automatically inserted — description to be completed.', {is_driver})
         """)
-    print(f"✅ dim_measurement_type: {len(new_measurements)} new type(s) inserted.")
+    logger.info("dim_measurement_type: %d new type(s) inserted.", len(new_measurements))
 
 # COMMAND ----------
 
@@ -364,6 +372,7 @@ else:
 # COMMAND ----------
 
 # DBTITLE 1,Cell 14
+# Source values from bookings CSV — do not translate (used as join keys against the Division column).
 DIVISION_META = {
     "Haute école de Gestion":
         ("HEG",     "HEG Valais-Wallis",          1),
@@ -389,7 +398,7 @@ df_div_new  = df_div_silver.join(df_div_gold, on="DivisionName", how="left_anti"
 new_divisions = df_div_new.collect()
 
 if not new_divisions:
-    print("✅ dim_division: no new divisions detected.")
+    logger.info("dim_division: no new divisions detected.")
 else:
     for row in new_divisions:
         name_raw = row["DivisionName"]
@@ -407,7 +416,7 @@ else:
             INSERT INTO dim_division (DivisionCode, DivisionName, SchoolName, IsActive)
             VALUES ('{code}', '{name_sql}', '{school.replace("'","''")}', {is_active})
         """)
-    print(f"✅ dim_division: {len(new_divisions)} new division(s) inserted.")
+    logger.info("dim_division: %d new division(s) inserted.", len(new_divisions))
 
 # COMMAND ----------
 
@@ -467,7 +476,7 @@ df_rooms_new  = df_rooms_silver.join(df_rooms_gold, on="RoomCode", how="left_ant
 new_rooms     = df_rooms_new.collect()
 
 if not new_rooms:
-    print("✅ dim_room: no new rooms detected.")
+    logger.info("dim_room: no new rooms detected.")
 else:
     for row in new_rooms:
         code = row["RoomCode"]
@@ -485,7 +494,7 @@ else:
                 ('{code_sql}', '{code_sql}', 'Bellevue', 'VS-BEL',
                  {wing}, {floor}, {room}, '{p["room_type"]}', NULL, 1)
         """)
-    print(f"✅ dim_room: {len(new_rooms)} new room(s) inserted.")
+    logger.info("dim_room: %d new room(s) inserted.", len(new_rooms))
 
 # COMMAND ----------
 
@@ -508,10 +517,10 @@ try:
     config_path = f"{config_base}/ml_models_config.json"
     raw = dbutils.fs.head(config_path, 65536)
     models = json.loads(raw)
-    print(f"✅ ML config loaded: {len(models)} model(s).")
+    logger.info("ML config loaded: %d model(s).", len(models))
 except Exception as e:
     # File missing → default values (first deployment)
-    print(f"⚠️  ML config not found ({e}) — using default values.")
+    logger.warning("ML config not found (%s) — using default values.", e)
     models = [
         {
             "ModelCode": "PV_PROD_V1",
@@ -561,7 +570,7 @@ for m in models:
                 ('{code}', '{name}', '{mtype}', '{target}', '{features}',
                  '{train_start}', '{train_end}', {is_active}, '{notes}')
         """)
-        print(f"✅ dim_prediction_model: new model '{code}' inserted.")
+        logger.info("dim_prediction_model: new model '%s' inserted.", code)
     else:
         # Check if ModelType or Features changed → UPDATE
         old = existing[code]
@@ -571,7 +580,7 @@ for m in models:
                 SET ModelType = '{mtype}', Features = '{features}', Notes = '{notes}'
                 WHERE ModelCode = '{code}'
             """)
-            print(f"✅ dim_prediction_model: model '{code}' updated (type or features changed).")
+            logger.info("dim_prediction_model: model '%s' updated (type or features changed).", code)
 
 # COMMAND ----------
 
@@ -591,7 +600,7 @@ try:
     tariff_path = f"{config_base}/electricity_tariff_config.json"
     raw_tariff  = dbutils.fs.head(tariff_path, 4096)
     tariff_cfg  = json.loads(raw_tariff)
-    print(f"✅ Tariff config loaded.")
+    logger.info("Tariff config loaded.")
 except Exception:
     tariff_cfg = {
         "TariffName":      "Standard HES-SO Valais",
@@ -599,7 +608,7 @@ except Exception:
         "EffectiveFrom":   "2023-01-01",
         "Notes":           "Initial tariff 0.15 CHF/kWh — from Bellevue dashboard."
     }
-    print("⚠️  Tariff config not found — using default tariff (0.15 CHF/kWh).")
+    logger.warning("Tariff config not found — using default tariff (0.15 CHF/kWh).")
 
 # Get active tariff (EffectiveTo IS NULL)
 df_tariff_gold = read_gold("ref_electricity_tariff").filter(col("EffectiveTo").isNull())
@@ -614,7 +623,7 @@ if not active:
             ('{tariff_cfg["TariffName"]}', {tariff_cfg["PricePerKwh_CHF"]},
              '{tariff_cfg["EffectiveFrom"]}', NULL,
              '{tariff_cfg.get("Notes","").replace("'","''")}')""")
-    print(f"✅ ref_electricity_tariff: initial tariff inserted ({tariff_cfg['PricePerKwh_CHF']} CHF/kWh).")
+    logger.info("ref_electricity_tariff: initial tariff inserted (%s CHF/kWh).", tariff_cfg['PricePerKwh_CHF'])
 elif float(active[0]["PricePerKwh_CHF"]) != float(tariff_cfg["PricePerKwh_CHF"]):
     # Tariff change → SCD2: close old, insert new
     exec_sql(f"""
@@ -629,9 +638,9 @@ elif float(active[0]["PricePerKwh_CHF"]) != float(tariff_cfg["PricePerKwh_CHF"])
             ('{tariff_cfg["TariffName"]}', {tariff_cfg["PricePerKwh_CHF"]},
              '{tariff_cfg["EffectiveFrom"]}', NULL,
              '{tariff_cfg.get("Notes","").replace("'","''")}')""")
-    print(f"✅ ref_electricity_tariff: new tariff {tariff_cfg['PricePerKwh_CHF']} CHF/kWh active.")
+    logger.info("ref_electricity_tariff: new tariff %s CHF/kWh active.", tariff_cfg['PricePerKwh_CHF'])
 else:
-    print(f"✅ ref_electricity_tariff: tariff unchanged ({active[0]['PricePerKwh_CHF']} CHF/kWh).")
+    logger.info("ref_electricity_tariff: tariff unchanged (%s CHF/kWh).", active[0]['PricePerKwh_CHF'])
 
 # COMMAND ----------
 
@@ -649,12 +658,12 @@ dims = [
     "dim_prediction_model", "ref_electricity_tariff",
 ]
 
-print("=" * 55)
-print(f"{'Table':<30} {'Rows':>8}  {'Last Update':>14}")
-print("=" * 55)
+logger.info("=" * 55)
+logger.info("%-30s %8s  %14s", "Table", "Rows", "Last Update")
+logger.info("=" * 55)
 for dim in dims:
     df = read_gold(dim)
     n  = df.count()
-    print(f"  {dim:<28} {n:>8}")
-print("=" * 55)
-print("✅ Step 1B completed — all Gold dimensions are up to date.")
+    logger.info("  %-28s %8d", dim, n)
+logger.info("=" * 55)
+logger.info("Step 1B completed — all Gold dimensions are up to date.")

--- a/databricks/notebooks/silver_gold_facts.py
+++ b/databricks/notebooks/silver_gold_facts.py
@@ -6,27 +6,27 @@
 
 # DBTITLE 1,Untitled
 # MAGIC %md
-# MAGIC # 🥈→🥇 Étape 2 — Chargement des tables de faits (Gold)
+# MAGIC # 🥈→🥇 Step 2 — Gold Fact Table Load
 # MAGIC
-# MAGIC Ce notebook lit les tables Silver (Parquet sur ADLS) et écrit les faits
-# MAGIC dans **Azure SQL BellevueEnergyDW** via JDBC.
+# MAGIC This notebook reads Silver tables (Parquet on ADLS) and writes facts
+# MAGIC into **Azure SQL BellevueEnergyDW** via JDBC.
 # MAGIC
-# MAGIC ### Stratégie de chargement : **Append incrémental par date**
+# MAGIC ### Load strategy: **incremental append by date**
 # MAGIC
-# MAGIC Chaque fait est identifié par une **watermark** (date max déjà chargée en Gold).
-# MAGIC Seules les lignes Silver postérieures à cette watermark sont insérées.
-# MAGIC Cela évite les doublons sans avoir à vider et recharger toutes les tables.
+# MAGIC Each fact is identified by a **watermark** (max DateKey already loaded into Gold).
+# MAGIC Only Silver rows after that watermark are inserted, avoiding duplicates
+# MAGIC without truncate-and-reload.
 # MAGIC
-# MAGIC | Table Gold                | Source Silver              | Grain              | Fréquence   |
-# MAGIC |---------------------------|----------------------------|--------------------|-------------|
-# MAGIC | `fact_solar_inverter`     | `solar_inverters/`         | 1-min × 5 onduleurs| Quotidien   |
-# MAGIC | `fact_solar_production`   | `solar_aggregated/`        | 15-min             | Quotidien   |
-# MAGIC | `fact_energy_consumption` | `consumption/`             | 15-min             | Quotidien   |
-# MAGIC | `fact_environment`        | `temperature/` + `humidity/`| 15-min (jointure) | Quotidien   |
-# MAGIC | `fact_weather_forecast`   | `weather_forecasts/`       | 3h × mesure × horiz| Quotidien   |
-# MAGIC | `fact_room_booking`       | `bookings/`                | événement/salle    | Hebdomadaire|
+# MAGIC | Gold table                | Silver source              | Grain                  | Frequency |
+# MAGIC |---------------------------|----------------------------|------------------------|-----------|
+# MAGIC | `fact_solar_inverter`     | `solar_inverters/`         | 1-min × 5 inverters    | Daily     |
+# MAGIC | `fact_solar_production`   | `solar_aggregated/`        | 15-min                 | Daily     |
+# MAGIC | `fact_energy_consumption` | `consumption/`             | 15-min                 | Daily     |
+# MAGIC | `fact_environment`        | `temperature/` + `humidity/`| 15-min (joined)       | Daily     |
+# MAGIC | `fact_weather_forecast`   | `weather_forecasts/`       | 3h × measurement × horizon | Daily |
+# MAGIC | `fact_room_booking`       | `bookings/`                | event / room           | Weekly    |
 # MAGIC
-# MAGIC > `fact_energy_prediction` est alimentée par le pipeline ML (KNIME) — hors scope ici.
+# MAGIC > `fact_energy_prediction` is loaded by the ML pipeline (KNIME) — out of scope here.
 
 # COMMAND ----------
 
@@ -37,6 +37,8 @@
 # COMMAND ----------
 
 # DBTITLE 1,Untitled
+import logging
+
 from pyspark.sql.functions import (
     col, lit, year, month, hour, minute,
     to_date, try_to_date, date_format, concat_ws,
@@ -45,8 +47,12 @@ from pyspark.sql.functions import (
 from pyspark.sql import DataFrame
 import datetime
 
+logger = logging.getLogger(__name__)
+if not logger.handlers:
+    logger.setLevel(logging.INFO)
+
 # ── ADLS Silver ────────────────────────────────────────────────────────────────
-# BUG B CORRIGÉ : storage_account_name et sql_server n'étaient pas déclarés
+# BUG B FIXED: storage_account_name and sql_server were not declared.
 storage_account_name = "adlsbellevuegrp3"
 storage_account_key  = dbutils.secrets.get(scope="keyvault-scope", key="adls-access-key")
 spark.conf.set(
@@ -77,10 +83,10 @@ import time
 
 def _jdbc_retry(fn, max_attempts: int = 5, initial_wait: int = 20):
     """
-    Retry helper pour Azure SQL Serverless — la base se met en pause après
-    inactivité et met ~20-60 s à redémarrer à la première connexion.
-    Stratégie : backoff linéaire (20s, 40s, 60s, 80s) sur les erreurs
-    'not currently available' uniquement. Les autres erreurs sont relancées immédiatement.
+    Retry helper for Azure SQL Serverless — the database pauses after
+    inactivity and takes ~20-60s to restart on the first connection.
+    Strategy: linear backoff (20s, 40s, 60s, 80s) on
+    'not currently available' errors only. Other errors are re-raised immediately.
     """
     wait = initial_wait
     for attempt in range(1, max_attempts + 1):
@@ -91,24 +97,26 @@ def _jdbc_retry(fn, max_attempts: int = 5, initial_wait: int = 20):
             if "not currently available" in msg or "connection" in msg.lower():
                 if attempt == max_attempts:
                     raise
-                print(f"⚠️  Azure SQL en cours de réveil (tentative {attempt}/{max_attempts}) "
-                      f"— nouvelle tentative dans {wait}s...")
+                logger.warning(
+                    "Azure SQL waking up (attempt %d/%d) — retrying in %ds...",
+                    attempt, max_attempts, wait,
+                )
                 time.sleep(wait)
                 wait += initial_wait
             else:
                 raise
 
 def read_gold(table: str) -> DataFrame:
-    """Lit une table Gold depuis Azure SQL (avec retry au réveil Serverless)."""
+    """Read a Gold table from Azure SQL (with retry on Serverless wake-up)."""
     return _jdbc_retry(
         lambda: spark.read.jdbc(url=jdbc_url, table=table, properties=jdbc_props)
     )
 
 def write_gold(df: DataFrame, table: str, batch_size: int = 20_000):
     """
-    Écrit un DataFrame en APPEND dans Azure SQL.
-    - batchsize   : nombre de lignes par batch JDBC (compromis mémoire/débit)
-    - numPartitions: parallélisme d'écriture (adapter selon le cluster)
+    Append a DataFrame to Azure SQL.
+    - batchsize    : rows per JDBC batch (memory/throughput trade-off)
+    - numPartitions: write parallelism (tune to cluster size)
     """
     (df.write
        .mode("append")
@@ -120,9 +128,9 @@ def write_gold(df: DataFrame, table: str, batch_size: int = 20_000):
 
 def get_watermark(table: str, date_col: str = "DateKey") -> int:
     """
-    Retourne le DateKey maximum déjà présent dans une table Gold.
-    Retourne 0 si la table est vide (premier chargement).
-    Format DateKey : YYYYMMDD (int).
+    Return the max DateKey already present in a Gold table.
+    Returns 0 when the table is empty (first load).
+    DateKey format: YYYYMMDD (int).
     """
     try:
         result = spark.read.jdbc(
@@ -136,21 +144,22 @@ def get_watermark(table: str, date_col: str = "DateKey") -> int:
 
 
 def ts_to_datekey(ts_col):
-    """Convertit un timestamp en DateKey YYYYMMDD (int)."""
+    """Convert a timestamp to DateKey YYYYMMDD (int)."""
     return date_format(ts_col, "yyyyMMdd").cast("int")
 
 
 def ts_to_timekey(ts_col):
-    """Convertit un timestamp en TimeKey = minutes depuis minuit (smallint)."""
+    """Convert a timestamp to TimeKey = minutes from midnight (smallint)."""
     return (hour(ts_col) * 60 + minute(ts_col)).cast("short")
 
 
 def french_date_to_english(date_col):
     """
-    Convertit les dates françaises en anglais pour parsing.
-    Ex: '8 janv. 2023' → '8 Jan 2023'
+    Convert French date tokens to English for parsing.
+    Example: '8 janv. 2023' -> '8 Jan 2023'.
     """
     result = date_col
+    # Source values from bookings CSV — do not translate (regex matches actual French data).
     french_months = [
         ("janv\\.", "Jan"), ("févr\\.", "Feb"), ("mars", "Mar"),
         ("avr\\.", "Apr"), ("mai", "May"), ("juin", "Jun"),
@@ -162,7 +171,7 @@ def french_date_to_english(date_col):
     return result
 
 
-print("✅ Configuration chargée.")
+logger.info("Configuration loaded.")
 
 # COMMAND ----------
 
@@ -170,13 +179,13 @@ print("✅ Configuration chargée.")
 # MAGIC %md
 # MAGIC ## 1 · `fact_solar_inverter`
 # MAGIC
-# MAGIC **Source** : `silver/solar_inverters/`  
-# MAGIC **Grain** : 1 ligne par minute par onduleur (5 onduleurs × ~1 440 min/jour)  
-# MAGIC **Lookups FK** :
+# MAGIC **Source**: `silver/solar_inverters/`
+# MAGIC **Grain**: 1 row per minute per inverter (5 inverters × ~1,440 min/day)
+# MAGIC **FK lookups**:
 # MAGIC - `InverterKey` ← `dim_inverter.InverterID`
-# MAGIC - `StatusKey`   ← `dim_inverter_status.StatusCode` (sentinelle 99 si inconnu)
+# MAGIC - `StatusKey`   ← `dim_inverter_status.StatusCode` (sentinel 99 if unknown)
 # MAGIC
-# MAGIC **Colonnes Silver** (toutes présentes grâce au BUG A corrigé dans silver_transformation.py) :
+# MAGIC **Silver columns** (all present thanks to BUG A fixed in silver_transformation.py):
 # MAGIC `log_timestamp`, `inverter_id`, `ac_power_w`, `daysum`, `status_code`,
 # MAGIC `pdc1`, `pdc2`, `udc1`, `udc2`, `is_failure`
 
@@ -184,9 +193,9 @@ print("✅ Configuration chargée.")
 
 # DBTITLE 1,Untitled
 wm_inverter = get_watermark("fact_solar_inverter")
-print(f"Watermark fact_solar_inverter : DateKey > {wm_inverter}")
+logger.info("Watermark fact_solar_inverter : DateKey > %d", wm_inverter)
 
-# Lookup tables (broadcast — petites dimensions)
+# Lookup tables (broadcast — small dimensions)
 df_dim_inv    = read_gold("dim_inverter").select(
     col("InverterKey"), col("InverterID")
 ).cache()
@@ -203,7 +212,7 @@ df_inv_silver = (
 )
 
 if df_inv_silver.isEmpty():
-    print("ℹ️  Aucune nouvelle ligne Silver — fact_solar_inverter déjà à jour.")
+    logger.info("No new Silver rows — fact_solar_inverter already up to date.")
 else:
     df_fact_inv = (
         df_inv_silver
@@ -212,11 +221,11 @@ else:
         .withColumn("TimeKey", ts_to_timekey(col("log_timestamp")))
         # Lookup InverterKey
         .join(df_dim_inv, col("inverter_id") == col("InverterID"), how="left")
-        # Lookup StatusKey (utilise 99 si le code est inconnu)
+        # Lookup StatusKey (falls back to 99 when the code is unknown)
         .join(df_dim_status, col("status_code") == col("StatusCode"), how="left")
         .withColumn("StatusKey", coalesce(col("StatusKey"), lit(99).cast("byte")))
-        # Mesures — BUG C CORRIGÉ : lecture des vraies colonnes Silver
-        # (le BUG A dans silver_transformation.py a ajouté ces colonnes dans l'unpivot)
+        # Measures — BUG C FIXED: read the real Silver columns
+        # (BUG A in silver_transformation.py added these columns to the unpivot).
         .withColumn("AcPower_W",     col("ac_power_w").cast("double"))
         .withColumn("DayEnergy_Kwh", col("daysum").cast("double"))
         .withColumn("DcPower1_W",    col("pdc1").cast("double"))
@@ -233,13 +242,13 @@ else:
             "DcPower1_W", "DcPower2_W", "DcVoltage1_V", "DcVoltage2_V",
             "IsFailure", "Year", "Month",
         )
-        .filter(col("InverterKey").isNotNull())  # rejette les onduleurs sans correspondance dim
+        .filter(col("InverterKey").isNotNull())  # reject inverters with no matching dim row
         .dropDuplicates(["DateKey", "TimeKey", "InverterKey"])
     )
 
     n = df_fact_inv.count()
     write_gold(df_fact_inv, "fact_solar_inverter")
-    print(f"✅ fact_solar_inverter : {n:,} lignes insérées (DateKey > {wm_inverter}).")
+    logger.info("fact_solar_inverter : %s rows inserted (DateKey > %d).", f"{n:,}", wm_inverter)
 
 df_dim_inv.unpersist()
 df_dim_status.unpersist()
@@ -250,16 +259,16 @@ df_dim_status.unpersist()
 # MAGIC %md
 # MAGIC ## 2 · `fact_solar_production`
 # MAGIC
-# MAGIC **Source** : `silver/solar_aggregated/`  
-# MAGIC **Grain** : 1 ligne par slot 15-min (production PV totale du bâtiment)  
-# MAGIC **Colonnes** : `CumulativeEnergy_Kwh`, `DeltaEnergy_Kwh`  
-# MAGIC `RetailValue_CHF` est une colonne calculée SQL (`DeltaEnergy_Kwh × 0.15`) — non à insérer.
+# MAGIC **Source**: `silver/solar_aggregated/`
+# MAGIC **Grain**: 1 row per 15-min slot (total building PV production)
+# MAGIC **Columns**: `CumulativeEnergy_Kwh`, `DeltaEnergy_Kwh`
+# MAGIC `RetailValue_CHF` is a SQL computed column (`DeltaEnergy_Kwh × 0.15`) — not inserted here.
 
 # COMMAND ----------
 
 # DBTITLE 1,Untitled
 wm_prod = get_watermark("fact_solar_production")
-print(f"Watermark fact_solar_production : DateKey > {wm_prod}")
+logger.info("Watermark fact_solar_production : DateKey > %d", wm_prod)
 
 df_prod_silver = (
     spark.read.parquet(f"{silver_base}/solar_aggregated/")
@@ -268,7 +277,7 @@ df_prod_silver = (
 )
 
 if df_prod_silver.isEmpty():
-    print("ℹ️  Aucune nouvelle ligne Silver — fact_solar_production déjà à jour.")
+    logger.info("No new Silver rows — fact_solar_production already up to date.")
 else:
     df_fact_prod = (
         df_prod_silver
@@ -278,14 +287,14 @@ else:
         .withColumn("DeltaEnergy_Kwh",      col("delta_value").cast("double"))
         .withColumn("Year",  year(col("timestamp")).cast("short"))
         .withColumn("Month", month(col("timestamp")).cast("byte"))
-        # RetailValue_CHF est calculée par SQL → ne pas l'inclure
+        # RetailValue_CHF is computed in SQL — do not include it here.
         .select("DateKey", "TimeKey", "CumulativeEnergy_Kwh", "DeltaEnergy_Kwh", "Year", "Month")
         .dropDuplicates(["DateKey", "TimeKey"])
     )
 
     n = df_fact_prod.count()
     write_gold(df_fact_prod, "fact_solar_production")
-    print(f"✅ fact_solar_production : {n:,} lignes insérées (DateKey > {wm_prod}).")
+    logger.info("fact_solar_production : %s rows inserted (DateKey > %d).", f"{n:,}", wm_prod)
 
 # COMMAND ----------
 
@@ -293,15 +302,15 @@ else:
 # MAGIC %md
 # MAGIC ## 3 · `fact_energy_consumption`
 # MAGIC
-# MAGIC **Source** : `silver/consumption/`  
-# MAGIC **Grain** : 1 ligne par slot 15-min (consommation électrique du bâtiment)  
-# MAGIC `CostCHF` est une colonne calculée SQL — non à insérer.
+# MAGIC **Source**: `silver/consumption/`
+# MAGIC **Grain**: 1 row per 15-min slot (building electrical consumption)
+# MAGIC `CostCHF` is a SQL computed column — not inserted here.
 
 # COMMAND ----------
 
 # DBTITLE 1,Untitled
 wm_conso = get_watermark("fact_energy_consumption")
-print(f"Watermark fact_energy_consumption : DateKey > {wm_conso}")
+logger.info("Watermark fact_energy_consumption : DateKey > %d", wm_conso)
 
 df_conso_silver = (
     spark.read.parquet(f"{silver_base}/consumption/")
@@ -310,7 +319,7 @@ df_conso_silver = (
 )
 
 if df_conso_silver.isEmpty():
-    print("ℹ️  Aucune nouvelle ligne Silver — fact_energy_consumption déjà à jour.")
+    logger.info("No new Silver rows — fact_energy_consumption already up to date.")
 else:
     df_fact_conso = (
         df_conso_silver
@@ -320,14 +329,14 @@ else:
         .withColumn("DeltaEnergy_Kwh",      col("delta_value").cast("double"))
         .withColumn("Year",  year(col("timestamp")).cast("short"))
         .withColumn("Month", month(col("timestamp")).cast("byte"))
-        # CostCHF est calculée par SQL → ne pas l'inclure
+        # CostCHF is computed in SQL — do not include it here.
         .select("DateKey", "TimeKey", "CumulativeEnergy_Kwh", "DeltaEnergy_Kwh", "Year", "Month")
         .dropDuplicates(["DateKey", "TimeKey"])
     )
 
     n = df_fact_conso.count()
     write_gold(df_fact_conso, "fact_energy_consumption")
-    print(f"✅ fact_energy_consumption : {n:,} lignes insérées (DateKey > {wm_conso}).")
+    logger.info("fact_energy_consumption : %s rows inserted (DateKey > %d).", f"{n:,}", wm_conso)
 
 # COMMAND ----------
 
@@ -335,18 +344,18 @@ else:
 # MAGIC %md
 # MAGIC ## 4 · `fact_environment`
 # MAGIC
-# MAGIC **Source** : `silver/temperature/` + `silver/humidity/`  
-# MAGIC **Grain** : 1 ligne par slot 15-min — jointure OUTER sur `timestamp`  
+# MAGIC **Source**: `silver/temperature/` + `silver/humidity/`
+# MAGIC **Grain**: 1 row per 15-min slot — OUTER join on `timestamp`
 # MAGIC
-# MAGIC Les deux sources ont la même fréquence 15-min mais peuvent avoir des trous.
-# MAGIC Un FULL OUTER JOIN garantit qu'aucune mesure n'est perdue si l'un des
-# MAGIC deux capteurs est défaillant sur un slot donné.
+# MAGIC Both sources share the same 15-min frequency but can have gaps.
+# MAGIC A FULL OUTER JOIN ensures no measurement is lost when either sensor
+# MAGIC is missing for a given slot.
 
 # COMMAND ----------
 
 # DBTITLE 1,Untitled
 wm_env = get_watermark("fact_environment")
-print(f"Watermark fact_environment : DateKey > {wm_env}")
+logger.info("Watermark fact_environment : DateKey > %d", wm_env)
 
 df_temp = (
     spark.read.parquet(f"{silver_base}/temperature/")
@@ -371,9 +380,9 @@ df_humi = (
 )
 
 if df_temp.isEmpty() and df_humi.isEmpty():
-    print("ℹ️  Aucune nouvelle ligne Silver — fact_environment déjà à jour.")
+    logger.info("No new Silver rows — fact_environment already up to date.")
 else:
-    # Full outer join sur timestamp pour ne rien perdre
+    # Full outer join on timestamp so nothing is lost.
     df_env_joined = df_temp.join(df_humi,
         df_temp["ts_temp"] == df_humi["ts_humi"], how="outer"
     )
@@ -396,7 +405,7 @@ else:
 
     n = df_fact_env.count()
     write_gold(df_fact_env, "fact_environment")
-    print(f"✅ fact_environment : {n:,} lignes insérées (DateKey > {wm_env}).")
+    logger.info("fact_environment : %s rows inserted (DateKey > %d).", f"{n:,}", wm_env)
 
 # COMMAND ----------
 
@@ -404,24 +413,24 @@ else:
 # MAGIC %md
 # MAGIC ## 5 · `fact_weather_forecast`
 # MAGIC
-# MAGIC **Source** : `silver/weather_forecasts/`  
-# MAGIC **Grain** : 1 ligne par (datetime × measurement × horizon de prévision)  
-# MAGIC **Lookups FK** :
-# MAGIC - `SiteKey`        ← `dim_weather_site.SiteName`   (Sierre uniquement en Silver)
+# MAGIC **Source**: `silver/weather_forecasts/`
+# MAGIC **Grain**: 1 row per (datetime × measurement × forecast horizon)
+# MAGIC **FK lookups**:
+# MAGIC - `SiteKey`        ← `dim_weather_site.SiteName`   (Sierre only in Silver)
 # MAGIC - `MeasurementKey` ← `dim_measurement_type.MeasurementCode`
 # MAGIC
-# MAGIC La colonne `Prediction` du Silver est un entier string `'00'`→`'45'`
-# MAGIC représentant l'horizon en pas de 3h → castée en SMALLINT.
+# MAGIC The Silver `Prediction` column is a string integer `'00'`–`'45'`
+# MAGIC representing the forecast horizon in 3h steps → cast to SMALLINT.
 # MAGIC
-# MAGIC **Note** : Les dates hors plage de `dim_date` (ex: DateKey 20221231) produisent
-# MAGIC une violation de FK JDBC et sont rejetées. Aucun filtre ad-hoc nécessaire :
-# MAGIC le Silver ne contient que des dates du jeu de données (2023-02 → 2023-05).
+# MAGIC **Note**: dates outside the `dim_date` range (e.g. DateKey 20221231) cause
+# MAGIC a JDBC FK violation and are rejected. No ad-hoc filter is needed:
+# MAGIC Silver only contains dates from the dataset (2023-02 → 2023-05).
 
 # COMMAND ----------
 
 # DBTITLE 1,Untitled
 wm_weather = get_watermark("fact_weather_forecast")
-print(f"Watermark fact_weather_forecast : DateKey > {wm_weather}")
+logger.info("Watermark fact_weather_forecast : DateKey > %d", wm_weather)
 
 df_dim_site = read_gold("dim_weather_site").select(
     col("SiteKey"), col("SiteName")
@@ -438,7 +447,7 @@ df_weather_silver = (
 )
 
 if df_weather_silver.isEmpty():
-    print("ℹ️  Aucune nouvelle ligne Silver — fact_weather_forecast déjà à jour.")
+    logger.info("No new Silver rows — fact_weather_forecast already up to date.")
 else:
     df_fact_weather = (
         df_weather_silver
@@ -459,14 +468,14 @@ else:
             "DateKey", "TimeKey", "SiteKey", "MeasurementKey",
             "PredictionHorizon", "ForecastValue", "Year", "Month",
         )
-        # Rejette les lignes sans FK valide (site ou mesure inconnus)
+        # Reject rows without a valid FK (unknown site or measurement).
         .filter(col("SiteKey").isNotNull() & col("MeasurementKey").isNotNull())
         .dropDuplicates(["DateKey", "TimeKey", "SiteKey", "MeasurementKey", "PredictionHorizon"])
     )
 
     n = df_fact_weather.count()
     write_gold(df_fact_weather, "fact_weather_forecast")
-    print(f"✅ fact_weather_forecast : {n:,} lignes insérées (DateKey > {wm_weather}).")
+    logger.info("fact_weather_forecast : %s rows inserted (DateKey > %d).", f"{n:,}", wm_weather)
 
 df_dim_site.unpersist()
 df_dim_meas.unpersist()
@@ -477,27 +486,27 @@ df_dim_meas.unpersist()
 # MAGIC %md
 # MAGIC ## 6 · `fact_room_booking`
 # MAGIC
-# MAGIC **Source** : `silver/bookings/`  
-# MAGIC **Grain** : 1 ligne par réservation (occurrence dans une salle)  
-# MAGIC **Lookups FK** :
+# MAGIC **Source**: `silver/bookings/`
+# MAGIC **Grain**: 1 row per booking (occurrence in a room)
+# MAGIC **FK lookups**:
 # MAGIC - `RoomKey`     ← `dim_room.RoomCode`
 # MAGIC - `DivisionKey` ← `dim_division.DivisionName`
 # MAGIC
-# MAGIC **Particularités** :
-# MAGIC - `DateKey` = date de l'occurrence (colonne `Date` du Silver)
-# MAGIC - `StartTimeKey` / `EndTimeKey` = `HH:MM` → minutes depuis minuit (colonnes `Heure_Debut` / `Heure_Fin`)
+# MAGIC **Notes**:
+# MAGIC - `DateKey` = date of the occurrence (Silver `Date` column)
+# MAGIC - `StartTimeKey` / `EndTimeKey` = `HH:MM` → minutes from midnight (Silver `Heure_Debut` / `Heure_Fin` columns)
 # MAGIC - `DurationMinutes` = EndTimeKey − StartTimeKey
-# MAGIC - `IsRecurring` : TRUE si `Date_Recurrence_Debut` ou `Date_Recurrence_Fin` non NULL
-# MAGIC - BUG D CORRIGÉ : le CSV avait 2 colonnes dupliquées "Date de début" et "Date de fin".
-# MAGIC   Renommées dans Silver → `Heure_Debut`, `Heure_Fin`, `Date_Recurrence_Debut`, `Date_Recurrence_Fin`.
-# MAGIC - BUG E CORRIGÉ : "29 févr. 2023" (date inexistante) → `try_to_date` retourne NULL,
-# MAGIC   filtrée par `filter(col("DateKey").isNotNull())`. Pas de filtre ad-hoc nécessaire.
+# MAGIC - `IsRecurring` : TRUE when `Date_Recurrence_Debut` or `Date_Recurrence_Fin` is non-NULL
+# MAGIC - BUG D FIXED: the CSV had two duplicate "Date de début" and "Date de fin" columns.
+# MAGIC   They were renamed in Silver → `Heure_Debut`, `Heure_Fin`, `Date_Recurrence_Debut`, `Date_Recurrence_Fin`.
+# MAGIC - BUG E FIXED: "29 févr. 2023" (non-existent date) → `try_to_date` returns NULL,
+# MAGIC   filtered out by `filter(col("DateKey").isNotNull())`. No ad-hoc filter needed.
 
 # COMMAND ----------
 
 # DBTITLE 1,Cell 16
 wm_booking = get_watermark("fact_room_booking")
-print(f"Watermark fact_room_booking : DateKey > {wm_booking}")
+logger.info("Watermark fact_room_booking : DateKey > %d", wm_booking)
 
 df_dim_room = read_gold("dim_room").select(
     col("RoomKey"), col("RoomCode")
@@ -512,21 +521,21 @@ df_booking_silver = (
     .filter(col("Date").isNotNull())
 )
 
-# Calcul du DateKey depuis la colonne Date (format texte français)
+# Compute DateKey from the Date column (French text format).
 df_booking_silver = (
     df_booking_silver
     .withColumn("date_en", french_date_to_english(col("Date")))
     .withColumn("ts_date", try_to_date(col("date_en"), "d MMM yyyy"))
     .withColumn("DateKey", date_format(col("ts_date"), "yyyyMMdd").cast("int"))
-    .filter(col("DateKey").isNotNull())  # Exclut les dates invalides (NULL)
+    .filter(col("DateKey").isNotNull())  # Drop invalid dates (NULL)
     .filter(col("DateKey") > wm_booking)
 )
 
 if df_booking_silver.isEmpty():
-    print("ℹ️  Aucune nouvelle ligne Silver — fact_room_booking déjà à jour.")
+    logger.info("No new Silver rows — fact_room_booking already up to date.")
 else:
     def time_str_to_minutes(time_col):
-        """Convertit 'HH:mm' en minutes depuis minuit pour TimeKey."""
+        """Convert 'HH:mm' to minutes from midnight (TimeKey)."""
         return (
             col(time_col).substr(1, 2).cast("int") * 60
             + col(time_col).substr(4, 2).cast("int")
@@ -537,14 +546,14 @@ else:
         # Lookup FK Room
         .join(df_dim_room,
               trim(col("Nom")) == col("RoomCode"), how="left")
-        # Lookup FK Division (NULL → rejeté par filter plus bas)
+        # Lookup FK Division (NULL → rejected by filter below)
         .join(df_dim_div,
               trim(col("Division")) == col("DivisionName"), how="left")
-        # BUG D CORRIGÉ : noms réels des colonnes après renommage Silver
-        # idx 3 (heure début réservation) → Heure_Debut     format HH:mm
-        # idx 4 (heure fin réservation)   → Heure_Fin       format HH:mm
-        # idx 11 (début récurrence)       → Date_Recurrence_Debut  format 'd MMM yyyy'
-        # idx 12 (fin récurrence)         → Date_Recurrence_Fin    format 'd MMM yyyy'
+        # BUG D FIXED: real column names after Silver rename.
+        # idx 3 (booking start time) → Heure_Debut             format HH:mm
+        # idx 4 (booking end time)   → Heure_Fin               format HH:mm
+        # idx 11 (recurrence start)  → Date_Recurrence_Debut   format 'd MMM yyyy'
+        # idx 12 (recurrence end)    → Date_Recurrence_Fin     format 'd MMM yyyy'
         .withColumn("StartTimeKey", time_str_to_minutes("Heure_Debut"))
         .withColumn("EndTimeKey",   time_str_to_minutes("Heure_Fin"))
         .withColumn("DurationMinutes",
@@ -554,9 +563,12 @@ else:
         .withColumn("RecurrenceStart", try_to_date(col("date_en_recur_start"), "d MMM yyyy"))
         .withColumn("date_en_recur_end", french_date_to_english(coalesce(col("Date_Recurrence_Fin"), lit(""))))
         .withColumn("RecurrenceEnd", try_to_date(col("date_en_recur_end"), "d MMM yyyy"))
-        # NOTE: IsRecurring est une colonne calculée SQL (computed column)
-        # → Ne PAS l'inclure dans l'INSERT, SQL Server la calcule automatiquement
-        # Mesures & métadonnées
+        # NOTE: IsRecurring is a SQL computed column — do NOT include it in the
+        # INSERT; SQL Server fills it automatically.
+        # Measures & metadata. Source values from bookings CSV
+        # (`Rés.-no`, `Type de réservation`, `Activité`, `Classe`,
+        # `Poste de dépenses`, `Périodicité`, `Remarque`,
+        # `Professeur_Masked`, `Utilisateur_Masked`) — do not translate.
         .withColumn("ReservationNo",
             when(col("`Rés.-no`").cast("int") == 0, lit(None))
             .otherwise(col("`Rés.-no`").cast("int")))
@@ -575,22 +587,22 @@ else:
             "BookingType", "Codes", "ProfessorMasked", "UserMasked",
             "ActivityType", "Class", "CostCenter", "Periodicity",
             "RecurrenceStart", "RecurrenceEnd", "Remark",
-            # IsRecurring retiré — colonne calculée SQL
+            # IsRecurring is omitted — SQL computed column.
         )
-        # Rejette les lignes sans FK valide (salle ou division inconnues)
+        # Reject rows without a valid FK (unknown room or division).
         .filter(col("RoomKey").isNotNull() & col("DivisionKey").isNotNull())
         .dropDuplicates(["DateKey", "StartTimeKey", "RoomKey", "ReservationNo"])
     )
 
     n = df_fact_booking.count()
     write_gold(df_fact_booking, "fact_room_booking")
-    print(f"✅ fact_room_booking : {n:,} lignes insérées (DateKey > {wm_booking}).")
+    logger.info("fact_room_booking : %s rows inserted (DateKey > %d).", f"{n:,}", wm_booking)
 
 df_dim_room.unpersist()
 df_dim_div.unpersist()
 
 # COMMAND ----------
 
-print("\n" + "="*80)
-print("✅ Chargement des tables de faits terminé.")
-print("="*80)
+logger.info("=" * 80)
+logger.info("Fact table load complete.")
+logger.info("=" * 80)

--- a/databricks/notebooks/silver_transformation.py
+++ b/databricks/notebooks/silver_transformation.py
@@ -36,12 +36,18 @@
 # COMMAND ----------
 
 # DBTITLE 1,Cell 4
+import logging
+
 from pyspark.sql.functions import (
     col, sha2, to_timestamp, concat_ws, when, lit, mean,
     explode, array, struct, regexp_extract, regexp_replace,
     coalesce, lag, translate, date_format,
 )
 from pyspark.sql.window import Window
+
+logger = logging.getLogger(__name__)
+if not logger.handlers:
+    logger.setLevel(logging.INFO)
 
 storage_account_name = "adlsbellevuegrp3"
 storage_account_key  = dbutils.secrets.get(scope="keyvault-scope", key="adls-access-key")
@@ -54,8 +60,8 @@ spark.conf.set(
 bronze_base = f"abfss://bronze@{storage_account_name}.dfs.core.windows.net"
 silver_base = f"abfss://silver@{storage_account_name}.dfs.core.windows.net"
 
-print(f"✅ Bronze: {bronze_base}")
-print(f"✅ Silver: {silver_base}")
+logger.info("Bronze: %s", bronze_base)
+logger.info("Silver: %s", silver_base)
 
 # COMMAND ----------
 
@@ -186,7 +192,7 @@ df_solar_inverters = (
 )
 
 df_solar_inverters.write.mode("overwrite").parquet(f"{silver_base}/solar_inverters/")
-print(f"✅ solar_inverters   → {df_solar_inverters.count():,} rows")
+logger.info("solar_inverters   -> %s rows", f"{df_solar_inverters.count():,}")
 
 # COMMAND ----------
 
@@ -255,7 +261,7 @@ df_solar_agg = (
 )
 
 df_solar_agg.write.mode("overwrite").parquet(f"{silver_base}/solar_aggregated/")
-print(f"✅ solar_aggregated  → {df_solar_agg.count():,} rows")
+logger.info("solar_aggregated  -> %s rows", f"{df_solar_agg.count():,}")
 
 # COMMAND ----------
 
@@ -283,12 +289,12 @@ df_sierre = (
 )
 
 df_sierre.write.mode("overwrite").parquet(f"{silver_base}/weather_forecasts/")
-print(f"✅ weather_forecasts → {df_sierre.count():,} rows")
+logger.info("weather_forecasts -> %s rows", f"{df_sierre.count():,}")
 
 df_futureweather_raw = spark.read.csv(f"{bronze_base}/future_forecasts/*.csv", header=True, inferSchema=True)
 
 df_sierre.write.mode("overwrite").parquet(f"{silver_base}/weather_future_forecasts/")
-print(f"✅ future_weather_forecasts → {df_sierre.count():,} rows")
+logger.info("future_weather_forecasts -> %s rows", f"{df_sierre.count():,}")
 
 
 
@@ -345,7 +351,7 @@ df_bookings = (
 # No ad-hoc filter needed here.
 
 df_bookings.write.mode("overwrite").parquet(f"{silver_base}/bookings/")
-print(f"✅ bookings          → {df_bookings.count():,} rows")
+logger.info("bookings          -> %s rows", f"{df_bookings.count():,}")
 
 # COMMAND ----------
 
@@ -436,7 +442,7 @@ def process_vetroz_sensor(
         df = df.withColumn(var_col, col(val_col) - lag(col(val_col), 1).over(w))
 
     df.write.mode("overwrite").parquet(f"{silver_base}/{silver_folder}/")
-    print(f"✅ {silver_folder:<20} → {df.count():,} rows")
+    logger.info("%-20s -> %s rows", silver_folder, f"{df.count():,}")
 
 # COMMAND ----------
 


### PR DESCRIPTION
Replace 144 print() calls with the standard `logging` module across the six PySpark notebooks. Translate all French display text (markdown headings, comments, docstrings, log messages) to English in silver_gold_facts.py; preserve French CSV column names, DIVISION_META lookup keys, and french_months regex patterns since they are matched against source data. Strip emojis from log/print output but keep them in `# MAGIC %md` markdown cells. No behavior change.