### PR TITLE
Cap room occupation percentage at 100% and handle unassigned divisions

### DIFF
--- a/sql/deploy_schema.sql
+++ b/sql/deploy_schema.sql
@@ -482,13 +482,13 @@ SELECT
     r.[Floor],
     r.Wing,
     r.RoomType,
-    div.SchoolName,
-    div.DivisionCode,
+    ISNULL(div.SchoolName, 'Unassigned')               AS SchoolName,
+    ISNULL(div.DivisionCode, 'Unassigned')             AS DivisionCode,
     COUNT(frb.BookingKey)                              AS BookingCount,
     ISNULL(SUM(frb.DurationMinutes), 0)                AS TotalBookedMinutes,
     -- Denominator = 600 minutes = 10h operating window (08:00–18:00).
-    -- Values > 100% indicate overlapping/double bookings on the same room.
-    ISNULL(SUM(frb.DurationMinutes), 0) * 100.0 / 600.0 AS OccupationPct,
+    -- Capped at 100 so Power BI visuals don't spike on overlapping bookings.
+    LEAST(ISNULL(SUM(frb.DurationMinutes), 0) * 100.0 / 600.0, 100.0) AS OccupationPct,
     MIN(t_start.TimeLabel)                             AS EarliestBookingTime,
     MAX(t_end.TimeLabel)                               AS LatestBookingTime
 FROM dbo.dim_date d
@@ -504,7 +504,8 @@ WHERE d.IsAcademicDay = 1
 GROUP BY d.FullDate, d.[Year], d.[Month], d.MonthName, d.WeekOfYear,
          d.DayName, d.IsWeekend, d.IsAcademicDay,
          r.RoomCode, r.[Floor], r.Wing, r.RoomType,
-         div.SchoolName, div.DivisionCode;
+         ISNULL(div.SchoolName, 'Unassigned'),
+         ISNULL(div.DivisionCode, 'Unassigned');
 GO
 
 -- Per-hour granularity for the heatmap matrix. One row per


### PR DESCRIPTION
## Summary
Updated the room booking analytics query to improve data visualization and handle edge cases with unassigned divisions.

## Key Changes
- **Occupation percentage capping**: Modified the `OccupationPct` calculation to use `LEAST()` function to cap values at 100%, preventing Power BI visuals from spiking when overlapping/double bookings occur on the same room
- **Unassigned division handling**: Added `ISNULL()` checks to replace NULL values in `SchoolName` and `DivisionCode` with 'Unassigned' for better data clarity
- **GROUP BY clause update**: Updated the GROUP BY clause to match the new ISNULL expressions for `SchoolName` and `DivisionCode` to ensure proper aggregation

## Implementation Details
- The occupation percentage is calculated as `(TotalBookedMinutes / 600 minutes) * 100`, where 600 minutes represents the 10-hour operating window (08:00–18:00)
- Previously, overlapping bookings could result in values exceeding 100%, which caused visualization issues
- The capping ensures the metric remains interpretable while still tracking actual booking activity
- Unassigned divisions are now explicitly labeled rather than appearing as NULL values in reports

https://claude.ai/code/session_01FGHjgVPtMwG5R3HVbskShj