### PR TITLE
fix: cap booking data to Spring 2023 semester (≤ 2023-05-31)

### DIFF
--- a/databricks/notebooks/silver_gold_facts.py
+++ b/databricks/notebooks/silver_gold_facts.py
@@ -611,6 +611,9 @@ df_booking_silver = (
     .withColumn("DateKey", date_format(col("ts_date"), "yyyyMMdd").cast("int"))
     .filter(col("DateKey").isNotNull())  # Drop invalid dates (NULL)
     .filter(col("DateKey") > wm_booking)
+    # Recurring bookings in the source CSV can have occurrence rows extending
+    # beyond the project's academic scope. Cap at end of Spring 2023 semester.
+    .filter(col("DateKey") <= 20230531)
 )
 
 if df_booking_silver.isEmpty():

--- a/sql/deploy_schema.sql
+++ b/sql/deploy_schema.sql
@@ -501,6 +501,7 @@ LEFT JOIN dbo.dim_time     t_start ON t_start.TimeKey = frb.StartTimeKey
 LEFT JOIN dbo.dim_time     t_end   ON t_end.TimeKey   = frb.EndTimeKey
 LEFT JOIN dbo.dim_division div     ON div.DivisionKey = frb.DivisionKey
 WHERE d.IsAcademicDay = 1
+  AND d.FullDate <= '2023-05-31'   -- project scope: Spring 2023 semester only
 GROUP BY d.FullDate, d.[Year], d.[Month], d.MonthName, d.WeekOfYear,
          d.DayName, d.IsWeekend, d.IsAcademicDay,
          r.RoomCode, r.[Floor], r.Wing, r.RoomType,
@@ -567,6 +568,7 @@ LEFT JOIN booking_hour_overlap bho
 LEFT JOIN dbo.dim_division div
        ON div.DivisionKey = bho.DivisionKey
 WHERE d.IsAcademicDay = 1
+  AND d.FullDate <= '2023-05-31'   -- project scope: Spring 2023 semester only
 GROUP BY d.FullDate, d.[Year], d.[Month], d.MonthName, d.WeekOfYear,
          d.DayName, d.IsWeekend, d.IsAcademicDay,
          r.RoomCode, r.[Floor], r.Wing, r.RoomType,


### PR DESCRIPTION
Recurring booking rows in the source CSV included future occurrences extending into 2024. Added DateKey ceiling in the Databricks load and a matching WHERE guard in both occupation views as a safety net.

https://claude.ai/code/session_01FGHjgVPtMwG5R3HVbskShj