### PR TITLE
Null out deltas across gaps >30min to prevent dashboard inflation

### DIFF
--- a/databricks/notebooks/silver_transformation.py
+++ b/databricks/notebooks/silver_transformation.py
@@ -304,14 +304,24 @@ df_solar_agg_parsed = _synthesize_xx00_rows(df_solar_agg_parsed, "cumulative_rea
 _w_solar = Window.partitionBy(lit(1)).orderBy("timestamp")
 df_solar_agg = (
     df_solar_agg_parsed
-    .withColumn("_prev", lag("cumulative_reading", 1).over(_w_solar))
+    .withColumn("_prev",    lag("cumulative_reading", 1).over(_w_solar))
+    .withColumn("_prev_ts", lag("timestamp",          1).over(_w_solar))
+    .withColumn(
+        "_gap_min",
+        (unix_timestamp("timestamp") - unix_timestamp("_prev_ts")) / 60,
+    )
     .withColumn(
         "delta_value",
         when(col("_prev").isNull(), lit(None).cast("double"))
         .when(col("cumulative_reading") < col("_prev"), lit(None).cast("double"))  # reset/overflow
+        # Gap > 30 min: previous reading is from a different day or after an
+        # outage. The cumulative jump across that gap is not a 15-min delta —
+        # null it out so it does not inflate dashboards (see fact_solar_production
+        # post-missing-day artefact).
+        .when(col("_gap_min") > 30, lit(None).cast("double"))
         .otherwise(col("cumulative_reading") - col("_prev")),
     )
-    .drop("_prev")
+    .drop("_prev", "_prev_ts", "_gap_min")
 )
 
 df_solar_agg.write.mode("overwrite").parquet(f"{silver_base}/solar_aggregated/")
@@ -490,21 +500,47 @@ def process_vetroz_sensor(
     if is_cumulative_meter:
         df = (
             df
-            .withColumn("_prev", lag(val_col, 1).over(w))
+            .withColumn("_prev",    lag(val_col,    1).over(w))
+            .withColumn("_prev_ts", lag("timestamp", 1).over(w))
+            .withColumn(
+                "_gap_min",
+                (unix_timestamp("timestamp") - unix_timestamp("_prev_ts")) / 60,
+            )
             .withColumn(
                 var_col,
                 # First row of the series → no previous reading, delta is unknown.
                 when(col("_prev").isNull(), lit(None).cast("double"))
                 # Counter went backwards → reset/overflow, do not emit a spike.
                 .when(col(val_col) < col("_prev"), lit(None).cast("double"))
+                # Gap > 30 min: cumulative jump across a missing-day or DST/outage
+                # window is not a 15-min delta — null it out instead of dumping
+                # the multi-hour cumulative into a single slot.
+                .when(col("_gap_min") > 30, lit(None).cast("double"))
                 .otherwise(col(val_col) - col("_prev"))
             )
-            .drop("_prev")
+            .drop("_prev", "_prev_ts", "_gap_min")
         )
 
     # ── Instantaneous sensor: var_col == val_col in source → true delta ────────
     if compute_real_delta:
-        df = df.withColumn(var_col, col(val_col) - lag(col(val_col), 1).over(w))
+        df = (
+            df
+            .withColumn("_prev",    lag(col(val_col), 1).over(w))
+            .withColumn("_prev_ts", lag("timestamp",  1).over(w))
+            .withColumn(
+                "_gap_min",
+                (unix_timestamp("timestamp") - unix_timestamp("_prev_ts")) / 60,
+            )
+            .withColumn(
+                var_col,
+                when(col("_prev").isNull(), lit(None).cast("double"))
+                # Same gap rule — a temperature change measured over a 30-hour
+                # window is not a 15-min delta.
+                .when(col("_gap_min") > 30, lit(None).cast("double"))
+                .otherwise(col(val_col) - col("_prev"))
+            )
+            .drop("_prev", "_prev_ts", "_gap_min")
+        )
 
     df.write.mode("overwrite").parquet(f"{silver_base}/{silver_folder}/")
     logger.info("%-20s -> %s rows", silver_folder, f"{df.count():,}")

--- a/sql/refresh_gap_nulling.sql
+++ b/sql/refresh_gap_nulling.sql
@@ -1,0 +1,67 @@
+-- =============================================================================
+-- Truncate the three Vetroz-derived fact tables so silver_gold_facts.py can
+-- repopulate them from scratch after the gap-aware delta nulling change in
+-- silver_transformation.py.
+--
+-- Why a full reload (not incremental):
+--   - silver_transformation.py overwrites silver/, but silver_gold_facts.py
+--     uses get_watermark() = MAX(DateKey) per fact table. With the watermark
+--     pinned at the existing latest DateKey, the now-nulled deltas for the
+--     post-missing-day rows (Feb 17, Mar 2, Apr 2, May 2) and any other
+--     gap > 30 min would not overwrite the existing inflated rows in gold.
+--   - Truncating the fact tables resets MAX(DateKey) to NULL → get_watermark
+--     falls back to 0 → every silver row is reloaded.
+--
+-- fact_solar_inverter is NOT truncated: silver/solar_inverters/ uses 5-min
+-- source telemetry, no gap-aware nulling applies there.
+--
+-- Run order
+-- ---------
+--   1. Re-run silver_transformation.py in Databricks first (silver/ is
+--      overwritten with nulled deltas wherever gap > 30 min).
+--   2. Run THIS script in SSMS / Azure Data Studio. Commits immediately.
+--   3. Re-run silver_gold_facts.py in Databricks.
+--   4. Refresh Power BI (Import-mode datasets need a manual refresh — the
+--      hour-0 spike on the "Consumption Pattern by Time of Day" chart will
+--      collapse from ~3,500 kWh to ~1,200 kWh once the post-missing-day
+--      00:15 row carries a NULL delta).
+-- =============================================================================
+
+SET NOCOUNT ON;
+SET XACT_ABORT ON;
+
+-- ---------- BEFORE ----------------------------------------------------------
+PRINT '--- BEFORE ---';
+SELECT 'fact_energy_consumption' AS tbl, COUNT(*) AS rows_before, MAX(DateKey) AS max_dk FROM dbo.fact_energy_consumption
+UNION ALL
+SELECT 'fact_solar_production',          COUNT(*),                MAX(DateKey)          FROM dbo.fact_solar_production
+UNION ALL
+SELECT 'fact_environment',               COUNT(*),                MAX(DateKey)          FROM dbo.fact_environment;
+
+-- The four post-missing-day 00:15 rows that should drop to NULL after reload:
+SELECT DateKey, TimeKey, ROUND(DeltaEnergy_Kwh, 1) AS delta_before
+FROM dbo.fact_energy_consumption
+WHERE TimeKey = 15
+  AND DateKey IN (20230217, 20230302, 20230402, 20230502)
+ORDER BY DateKey;
+
+-- ---------- TRUNCATE --------------------------------------------------------
+TRUNCATE TABLE dbo.fact_energy_consumption;
+TRUNCATE TABLE dbo.fact_solar_production;
+TRUNCATE TABLE dbo.fact_environment;
+
+PRINT 'Truncated 3 fact tables. Re-run silver_gold_facts.py to repopulate from silver.';
+
+-- ---------- AFTER (run again after silver_gold_facts.py) -------------------
+-- Expected: the four post-missing-day 00:15 rows now carry NULL DeltaEnergy_Kwh.
+-- SELECT DateKey, TimeKey, DeltaEnergy_Kwh AS delta_after
+-- FROM dbo.fact_energy_consumption
+-- WHERE TimeKey = 15
+--   AND DateKey IN (20230217, 20230302, 20230402, 20230502)
+-- ORDER BY DateKey;
+--
+-- Expected: hour-0 average drops to ≈ TimeKey 30 / 45 average (~10.85 kWh).
+-- SELECT TimeKey, ROUND(AVG(DeltaEnergy_Kwh), 2) AS avg_delta
+-- FROM dbo.fact_energy_consumption
+-- WHERE TimeKey IN (0, 15, 30, 45)
+-- GROUP BY TimeKey ORDER BY TimeKey;


### PR DESCRIPTION
## Summary
This PR implements gap-aware delta nulling in the silver layer transformation to prevent inflated values from appearing in dashboards when data gaps exceed 30 minutes. When a cumulative meter or sensor reading is missing for >30 minutes, the delta calculated across that gap is nulled rather than being attributed to a single 15-minute slot.

## Key Changes

- **Gap detection logic**: Added `_gap_min` calculation across all delta computations (cumulative meters, instantaneous sensors, and solar aggregation) to measure time elapsed between consecutive readings
- **Conditional nulling**: Modified delta calculations to return `NULL` when `_gap_min > 30`, preventing multi-hour cumulative jumps from inflating a single 15-minute slot
- **Applied to three data flows**:
  - Solar aggregated production (cumulative readings)
  - Vetroz cumulative meters (energy consumption, solar production)
  - Vetroz instantaneous sensors (environment/temperature data)
- **SQL refresh script**: Added `sql/refresh_gap_nulling.sql` to truncate the three gold fact tables, forcing a full reload from the nulled silver data (incremental reload would skip the corrected rows due to watermark logic)

## Implementation Details

- Gap calculation: `(unix_timestamp("timestamp") - unix_timestamp("_prev_ts")) / 60` converts seconds to minutes
- Threshold: 30 minutes chosen to catch missing-day gaps, DST transitions, and outages while preserving normal 15-minute intervals
- Cleanup: Temporary columns (`_prev`, `_prev_ts`, `_gap_min`) are dropped after delta computation
- The script includes before/after validation queries to verify the post-missing-day 00:15 rows (Feb 17, Mar 2, Apr 2, May 2) now carry NULL deltas

## Run Order
1. Re-run `silver_transformation.py` (silver layer overwritten with nulled deltas)
2. Execute the SQL refresh script (truncates gold fact tables)
3. Re-run `silver_gold_facts.py` (reloads from corrected silver data)
4. Refresh Power BI datasets (hour-0 spike on consumption pattern chart will collapse from ~3,500 kWh to ~1,200 kWh)

https://claude.ai/code/session_01F95t9bumKc713yEFfWJrFY