### PR TITLE
Fix ML export: correct solar source, weather LOCF, and is_academic_day

### DIFF
--- a/databricks/notebooks/ml_export_to_knime.py
+++ b/databricks/notebooks/ml_export_to_knime.py
@@ -47,7 +47,8 @@ from pyspark.sql.functions import (
     when, coalesce, to_timestamp, date_format,
     regexp_replace, regexp_extract, translate,
     concat_ws, mean as spark_mean, count as spark_count,
-    explode, sequence, expr
+    explode, sequence, expr,
+    last, unix_timestamp, sum as F_sum,
 )
 from pyspark.sql.window import Window
 from pyspark.sql import DataFrame
@@ -86,21 +87,53 @@ logger.info("ML     : %s", ml_base)
 # COMMAND ----------
 
 # DBTITLE 1,Untitled
-df_solar = (
+# Pass 1: *-PV.csv aggregated source (Jan 1 – Feb 19 2023)
+df_solar_pv = (
     spark.read.parquet(f"{silver_base}/solar_aggregated/")
     .filter(col("timestamp").isNotNull())
     .filter(col("delta_value").isNotNull())
-    # Exclude outliers (negative production is physically impossible)
     .filter(col("delta_value") >= 0)
     .select(
         col("timestamp"),
         col("delta_value").cast("double").alias("production_delta_kwh"),
     )
+)
+
+# Pass 2: inverter Pac integration (Feb 20 – end of dataset).
+# Mirrors the silver_gold_facts.py pass-2b logic: floor each 5-min
+# inverter reading into its 15-min bucket, sum Pac across all inverters,
+# convert W×5min to kWh via Σ(Pac)/12000.
+df_solar_inv_raw = (
+    spark.read.parquet(f"{silver_base}/solar_inverters/")
+    .filter(col("log_timestamp").isNotNull())
+    .withColumn(
+        "ts15",
+        expr("timestamp_seconds(floor(unix_timestamp(log_timestamp) / 900) * 900)").cast("timestamp"),
+    )
+    .withColumn("ac_power_w", coalesce(col("ac_power_w").cast("double"), lit(0.0)))
+)
+
+df_solar_inv = (
+    df_solar_inv_raw
+    .groupBy("ts15")
+    .agg((F_sum(col("ac_power_w")) / lit(12000.0)).alias("production_delta_kwh"))
+    .withColumnRenamed("ts15", "timestamp")
+    .filter(col("production_delta_kwh") >= 0)
+)
+
+# Union: PV-CSV for slots it covers; inverter data for the rest.
+df_solar = (
+    df_solar_pv
+    .unionByName(
+        df_solar_inv.join(
+            df_solar_pv.select("timestamp"), "timestamp", "left_anti"
+        )
+    )
     .dropDuplicates(["timestamp"])
     .orderBy("timestamp")
 )
 
-logger.info("solar_aggregated   : %s rows", f"{df_solar.count():,}")
+logger.info("solar (pv + inverter): %s rows", f"{df_solar.count():,}")
 df_solar.show(3, truncate=False)
 
 # COMMAND ----------
@@ -240,14 +273,14 @@ w_ff = Window.orderBy("timestamp").rowsBetween(Window.unboundedPreceding, 0)
 
 df_weather_15min = (
     df_weather_joined
-    .withColumn("irradiance_wm2",     coalesce(col("irradiance_wm2"),    lit(None)))
-    .withColumn("irradiance_wm2",     spark_mean("irradiance_wm2").over(w_ff))
-    .withColumn("temp_c",             coalesce(col("temp_c"),            lit(None)))
-    .withColumn("temp_c",             spark_mean("temp_c").over(w_ff))
-    .withColumn("humidity_pct",       coalesce(col("humidity_pct"),      lit(None)))
-    .withColumn("humidity_pct",       spark_mean("humidity_pct").over(w_ff))
-    .withColumn("precipitation_kgm2", coalesce(col("precipitation_kgm2"), lit(None)))
-    .withColumn("precipitation_kgm2", spark_mean("precipitation_kgm2").over(w_ff))
+    # Last-observation-carried-forward: propagate each 3h measurement to the
+    # 11 subsequent 15-min slots until the next measurement arrives.
+    # last(..., ignorenulls=True) over [unbounded preceding → current row]
+    # picks the most recent non-null value, NOT a running average.
+    .withColumn("irradiance_wm2",     last("irradiance_wm2",     ignorenulls=True).over(w_ff))
+    .withColumn("temp_c",             last("temp_c",             ignorenulls=True).over(w_ff))
+    .withColumn("humidity_pct",       last("humidity_pct",       ignorenulls=True).over(w_ff))
+    .withColumn("precipitation_kgm2", last("precipitation_kgm2", ignorenulls=True).over(w_ff))
     .filter(col("irradiance_wm2").isNotNull())  # Remove slots before first weather measurement
 )
 
@@ -370,9 +403,23 @@ def add_time_features(df: DataFrame, ts_col: str = "timestamp") -> DataFrame:
     - month         : 1–12
     - day_of_week   : 1=Sunday … 7=Saturday (Spark convention)
     - is_weekend    : 1 if Saturday or Sunday
-    - is_academic_day : 1 if Monday–Friday (academic period Feb–May 2023)
+    - is_academic_day : 1 if weekday AND not a HES-SO Valais school holiday
     - quarter_hour  : daily slot index 0–95 (identifies the 15-min slot in the day)
+
+    HES-SO Valais Spring 2023 non-academic periods in the dataset window:
+      Carnival:      Feb 20–24 (Mon–Fri school break)
+      Easter break:  Apr 6–21  (Pâques, Valais school holiday)
+      Labour Day:    May 1     (federal public holiday)
     """
+    # Date string for easy comparison (yyyy-MM-dd)
+    date_str = date_format(col(ts_col), "yyyy-MM-dd")
+
+    # Non-academic weekdays: Carnival week + Easter break + Labour Day
+    _carnival   = (date_str >= lit("2023-02-20")) & (date_str <= lit("2023-02-24"))
+    _easter     = (date_str >= lit("2023-04-06")) & (date_str <= lit("2023-04-21"))
+    _labour_day = date_str == lit("2023-05-01")
+    _holiday    = _carnival | _easter | _labour_day
+
     return (
         df
         .withColumn("hour",           hour(col(ts_col)).cast("int"))
@@ -382,11 +429,9 @@ def add_time_features(df: DataFrame, ts_col: str = "timestamp") -> DataFrame:
         .withColumn("is_weekend",
             when(dayofweek(col(ts_col)).isin(1, 7), 1).otherwise(0).cast("int"))
         .withColumn("is_academic_day",
-            # Monday–Friday during dataset period (Feb–May 2023)
-            when(
-                (dayofweek(col(ts_col)).isin(1, 7) == False),
-                1
-            ).otherwise(0).cast("int"))
+            when(dayofweek(col(ts_col)).isin(1, 7), 0)  # weekend → 0
+            .when(_holiday, 0)                           # school holiday → 0
+            .otherwise(1).cast("int"))
         .withColumn("quarter_hour",
             (col("hour") * 4 + col("minute") / 15).cast("int"))
     )

--- a/sql/deploy_schema.sql
+++ b/sql/deploy_schema.sql
@@ -658,6 +658,14 @@ GO
 
 CREATE OR ALTER VIEW dbo.vw_prediction_accuracy
 AS
+-- One row per FullDate × ModelCode, using only the most recent prediction run.
+-- Filtering to MAX(PredictionRunDateKey) per DateKey prevents double-counting
+-- when the ML pipeline reruns on the same calendar day.
+WITH latest_run AS (
+    SELECT DateKey, MAX(PredictionRunDateKey) AS LatestRunDateKey
+    FROM dbo.fact_energy_prediction
+    GROUP BY DateKey
+)
 SELECT
   d.FullDate,
   m.ModelCode,
@@ -672,9 +680,72 @@ SELECT
   CAST(SUM(ABS(p.PredictedConsumption_Kwh - p.ActualConsumption_Kwh))
        / NULLIF(SUM(p.ActualConsumption_Kwh), 0) AS DECIMAL(10,6))        AS ConsumptionMape
 FROM dbo.fact_energy_prediction p
-JOIN dbo.dim_date             d ON d.DateKey  = p.DateKey
-JOIN dbo.dim_prediction_model m ON m.ModelKey = p.ModelKey
+JOIN dbo.dim_date             d  ON d.DateKey  = p.DateKey
+JOIN dbo.dim_prediction_model m  ON m.ModelKey = p.ModelKey
+JOIN latest_run              lr  ON lr.DateKey = p.DateKey
+                                AND lr.LatestRunDateKey = p.PredictionRunDateKey
 GROUP BY d.FullDate, m.ModelCode, m.ModelName, p.PredictionRunDateKey;
+GO
+
+-- ── Energy & Finance overlay: one row per day with actuals + predictions ───────
+-- Joins the daily energy balance with the latest-run predictions from both
+-- models so Power BI can draw "Predicted vs Actual" lines on the same axis
+-- without a ModelCode pivot step in DAX.
+CREATE OR ALTER VIEW dbo.vw_daily_energy_with_predictions
+AS
+WITH daily_prod AS (
+    SELECT DateKey, SUM(DeltaEnergy_Kwh) AS TotalProduction_Kwh
+    FROM   dbo.fact_solar_production
+    GROUP BY DateKey
+),
+daily_cons AS (
+    SELECT DateKey, SUM(DeltaEnergy_Kwh) AS TotalConsumption_Kwh
+    FROM   dbo.fact_energy_consumption
+    GROUP BY DateKey
+),
+latest_run AS (
+    SELECT DateKey, MAX(PredictionRunDateKey) AS LatestRunDateKey
+    FROM   dbo.fact_energy_prediction
+    GROUP BY DateKey
+),
+pred_prod AS (
+    SELECT p.DateKey, SUM(p.PredictedProduction_Kwh) AS PredictedProduction_Kwh
+    FROM   dbo.fact_energy_prediction p
+    JOIN   latest_run lr ON lr.DateKey = p.DateKey AND lr.LatestRunDateKey = p.PredictionRunDateKey
+    JOIN   dbo.dim_prediction_model m ON m.ModelKey = p.ModelKey AND m.ModelCode = 'PV_PROD_V1'
+    GROUP BY p.DateKey
+),
+pred_cons AS (
+    SELECT p.DateKey, SUM(p.PredictedConsumption_Kwh) AS PredictedConsumption_Kwh
+    FROM   dbo.fact_energy_prediction p
+    JOIN   latest_run lr ON lr.DateKey = p.DateKey AND lr.LatestRunDateKey = p.PredictionRunDateKey
+    JOIN   dbo.dim_prediction_model m ON m.ModelKey = p.ModelKey AND m.ModelCode = 'CONS_V1'
+    GROUP BY p.DateKey
+)
+SELECT
+    d.FullDate,
+    d.[Year],
+    d.[Month],
+    d.MonthName,
+    (d.[Year] * 100 + d.[Month])                                              AS YearMonthKey,
+    CONVERT(NCHAR(7), d.FullDate, 126)                                        AS YearMonthLabel,
+    d.IsWeekend,
+    d.IsAcademicDay,
+    -- Actuals
+    ISNULL(fp.TotalProduction_Kwh,  0)                                        AS TotalProduction_Kwh,
+    ISNULL(fc.TotalConsumption_Kwh, 0)                                        AS TotalConsumption_Kwh,
+    ISNULL(fc.TotalConsumption_Kwh, 0) - ISNULL(fp.TotalProduction_Kwh, 0)   AS NetConsumption_Kwh,
+    CASE WHEN ISNULL(fc.TotalConsumption_Kwh, 0) > 0
+         THEN ISNULL(fp.TotalProduction_Kwh, 0) / fc.TotalConsumption_Kwh
+         ELSE 0 END                                                            AS SelfSufficiencyRatio,
+    -- Predictions (NULL when ML pipeline has not yet run for the day)
+    pp.PredictedProduction_Kwh,
+    pc.PredictedConsumption_Kwh
+FROM dbo.dim_date d
+LEFT JOIN daily_prod fp ON fp.DateKey = d.DateKey
+LEFT JOIN daily_cons fc ON fc.DateKey = d.DateKey
+LEFT JOIN pred_prod  pp ON pp.DateKey = d.DateKey
+LEFT JOIN pred_cons  pc ON pc.DateKey = d.DateKey;
 GO
 
 ----------------------------------------------------------------------


### PR DESCRIPTION
Three bugs in ml_export_to_knime.py were causing the solar GBT model to train on effectively no data, and both models to receive incorrect weather features:

1. Solar production source (critical): the notebook read only silver/solar_aggregated/ which ends Feb 19 2023, while the KNIME training window starts Feb 20. The inner join produced zero training rows for the entire solar model. Fixed by mirroring the silver_gold_facts.py two-pass approach: use solar_aggregated/ for Jan 1–Feb 19, then union with Pac-based integration from solar_inverters/ for Feb 20 onwards (same Σ(Pac_W)/12000 formula as the gold load).

2. Weather forward-fill (significant): spark_mean(...).over(w_ff) was computing a running cumulative average of all previous weather values instead of last-observation-carried-forward. At 18:00 the model was receiving the mean of every 3h measurement since data start rather than the 15:00 reading. Replaced with last(..., ignorenulls=True).over(w_ff).

3. is_academic_day (design): the feature was identical to 1 - is_weekend (checked only weekday vs weekend), making it perfectly collinear and giving the GBT model no new information about the school calendar. Replaced with a proper implementation that also excludes HES-SO Valais Spring 2023 school holidays: Carnival week (Feb 20–24), Easter break (Apr 6–21), and Labour Day (May 1).

Also removes the no-op coalesce(col(...), lit(None)) calls in the weather forward-fill block.

SQL (deploy_schema.sql):
- vw_prediction_accuracy: filter to MAX(PredictionRunDateKey) per DateKey so repeated ML pipeline runs don't double-count predicted values in DAX.
- vw_daily_energy_with_predictions (new): one row per day with both actual production/consumption and the latest-run predictions from both models, for direct use in the Power BI Energy & Finance overlay without a DAX ModelCode pivot.

https://claude.ai/code/session_01F95t9bumKc713yEFfWJrFY