### PR TITLE
fix: add .nojekyll and GitHub Pages setup guide for HTML architecture…

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -5,7 +5,11 @@ On-premises sources are ingested daily into an Azure Medallion Lakehouse,
 transformed by Databricks, scored by a KNIME ML server, and served to SAP
 Analytics Cloud and Power BI.
 
-> **Interactive diagram** — [View live architecture](https://sandersdHES.github.io/ADF_DataCycleProject/bellevue_architecture.html) *(requires GitHub Pages to be enabled — see setup below)*
+> **Interactive diagram** — [View live architecture](https://sandersdHES.github.io/ADF_DataCycleProject/bellevue_architecture.html)
+>
+> **GitHub Pages setup (one-time):** Go to **Settings → Pages → Source**, choose **Deploy from a branch**, select branch `main` and folder `/docs`, then click **Save**. The diagram will be live at the URL above within ~1 minute.
+>
+> *The HTML file is at `docs/bellevue_architecture.html`. GitHub renders `.html` files as raw source in the repository view — GitHub Pages is the only way to run it as a live interactive page.*
 
 ---
 


### PR DESCRIPTION
… diagram

GitHub renders .html files as raw source in repo/wiki views. The interactive architecture diagram only works via GitHub Pages. This commit adds the missing one-time setup instructions to ARCHITECTURE.md (the dangling "see setup below" now has a section) and adds docs/.nojekyll so Jekyll does not interfere with the static HTML when Pages is enabled from the /docs folder.

https://claude.ai/code/session_01NNFwEfnYeVBezNsN1pWyn1