### PR TITLE
feat: add GitHub Actions workflow to deploy docs/ to GitHub Pages

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,33 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/configure-pages@v5
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/
+
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -7,7 +7,7 @@ Analytics Cloud and Power BI.
 
 > **Interactive diagram** — [View live architecture](https://sandersdHES.github.io/ADF_DataCycleProject/bellevue_architecture.html)
 >
-> **GitHub Pages setup (one-time):** Go to **Settings → Pages → Source**, choose **Deploy from a branch**, select branch `main` and folder `/docs`, then click **Save**. The diagram will be live at the URL above within ~1 minute.
+> **GitHub Pages setup (one-time):** Go to **Settings → Pages → Source**, select **GitHub Actions**, then click **Save**. The `deploy-pages.yml` workflow will deploy the `docs/` folder automatically on every push to `main`.
 >
 > *The HTML file is at `docs/bellevue_architecture.html`. GitHub renders `.html` files as raw source in the repository view — GitHub Pages is the only way to run it as a live interactive page.*
 


### PR DESCRIPTION
The github-pages environment existed but no workflow ever fired a deployment, causing the architecture diagram URL to return 404. This adds deploy-pages.yml which uploads docs/ as a Pages artifact and deploys it on every push to main. Also updates ARCHITECTURE.md setup note to match the Actions-based source.

https://claude.ai/code/session_01NNFwEfnYeVBezNsN1pWyn1